### PR TITLE
Fix 'unusual meta field' rule linter failure

### DIFF
--- a/data-manipulation/encryption/rc6/encrypt-data-using-rc6.yml
+++ b/data-manipulation/encryption/rc6/encrypt-data-using-rc6.yml
@@ -8,7 +8,7 @@ rule:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     examples:
       - D87BA0BFCE1CDB17FD243B8B1D247E88:0x402390
-    note: both RC5 and RC6 use these same constants. RC6 is probably more common.
+  # both RC5 and RC6 use these same constants. RC6 is probably more common.
   features:
     - and:
       # ref: https://github.com/stamparm/cryptospecs/blob/master/symmetrical/sources/rc6.c#L66


### PR DESCRIPTION
Change the field `note` by a comment to fix the following failure:
```
FAIL: unusual meta field: Remove the meta field: "note"
```