### PR TITLE
Change characteristic syntax in rules

### DIFF
--- a/anti-analysis/anti-debugging/debugger-detection/check-for-peb-beingdebugged-flag.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-peb-beingdebugged-flag.yml
@@ -12,5 +12,5 @@ rule:
       - Practical Malware Analysis Lab 16-01.exe_:0x403530
   features:
     - and:
-      - characteristic(peb access): true
+      - characteristic: peb access
       - offset: 2 = PEB.BeingDebugged

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-peb-ntglobalflag-flag.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-peb-ntglobalflag-flag.yml
@@ -13,7 +13,7 @@ rule:
       - Practical Malware Analysis Lab 16-01.exe_:0x403530
   features:
     - and:
-      - characteristic(peb access): true
+      - characteristic: peb access
       - or:
         # 32-bit
         - offset: 0x68 = PEB.NtGlobalFlag

--- a/anti-analysis/obfuscation/string/stackstring/contain-obfuscated-stackstrings.yml
+++ b/anti-analysis/obfuscation/string/stackstring/contain-obfuscated-stackstrings.yml
@@ -11,4 +11,4 @@ rule:
     examples:
       - Practical Malware Analysis Lab 16-03.exe_:0x4013D0
   features:
-    - characteristic(stack string): true
+    - characteristic: stack string

--- a/anti-analysis/packer/generic/packed-with-generic-packer.yml
+++ b/anti-analysis/packer/generic/packed-with-generic-packer.yml
@@ -18,4 +18,4 @@ rule:
       - or:
         - mnemonic: popa
         - mnemonic: popad  # vivisect
-      - characteristic(cross section flow): true
+      - characteristic: cross section flow

--- a/data-manipulation/checksum/crc32/hash-data-with-crc32.yml
+++ b/data-manipulation/checksum/crc32/hash-data-with-crc32.yml
@@ -13,5 +13,5 @@ rule:
         - mnemonic: shr
         - number: 0xEDB88320
         - number: 8
-        - characteristic(nzxor): true
+        - characteristic: nzxor
       - api: RtlComputeCrc32

--- a/data-manipulation/encoding/xor/encode-data-using-xor.yml
+++ b/data-manipulation/encoding/xor/encode-data-using-xor.yml
@@ -10,8 +10,8 @@ rule:
       - 2D3EDC218A90F03089CC01715A9F047F:0x403D7E
   features:
     - and:
-      - characteristic(tight loop): true
-      - characteristic(nzxor): true
+      - characteristic: tight loop
+      - characteristic: nzxor
       # Reduce false positives
       - not:
         - or:

--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-ksa.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-ksa.yml
@@ -17,7 +17,7 @@ rule:
         - basic block:
           - and:
             # TODO misses if regular loop is used
-            - characteristic(tight loop): true
+            - characteristic: tight loop
             - or:
               - number: 0xFF
               - number: 0x100

--- a/host-interaction/file-system/files/list/enumerate-files-via-ntdll-functions.yml
+++ b/host-interaction/file-system/files/list/enumerate-files-via-ntdll-functions.yml
@@ -20,4 +20,4 @@ rule:
       - optional:
         - api: ntdll.RtlAllocateHeap
         - match: contain loop
-        - characteristic(indirect call): true
+        - characteristic: indirect call

--- a/lib/contain-loop.yml
+++ b/lib/contain-loop.yml
@@ -8,7 +8,7 @@ rule:
       - 08AC667C65D36D6542917655571E61C8:0x406EAA
   features:
     - or:
-      - characteristic(loop): true
-      - characteristic(recursive call): true
+      - characteristic: loop
+      - characteristic: recursive call
       - basic block:
-        - characteristic(tight loop): true
+        - characteristic: tight loop

--- a/linking/runtime-linking/access-peb-ldr_data.yml
+++ b/linking/runtime-linking/access-peb-ldr_data.yml
@@ -14,7 +14,7 @@ rule:
       - and:
         # resolve the PEB
         - or:
-          - characteristic(peb access): true
+          - characteristic: peb access
 
         # x86 Windows uses fs:0 to access the TIB which contains SEH information at offset 0
         # checking for fs:0 and a (possibly unrelated) number or offset often results in false positives
@@ -37,12 +37,12 @@ rule:
       - and:
         # resolve the PEB
         - or:
-          - characteristic(peb access): true
+          - characteristic: peb access
           # in the case of CallObfuscator, gs:[rax]
           # ref: https://github.com/d35ha/CallObfuscator/blob/5834aff9ff4511f1408ae4ce80b79737af4ae77b/ShellCode/shell_x64.asm#L8
           - and:
             - number: 0x60  # x64
-            - characteristic(gs access): true
+            - characteristic: gs access
           # in 0f5d5d07c6533bc6d991836ce79daaa1
           # then we have:
           #
@@ -50,7 +50,7 @@ rule:
           #     mov edx, fs:[edx+30h]
           - and:
             - offset: 0x60  # x64
-            - characteristic(gs access): true
+            - characteristic: gs access
 
         # LDR_DATA* Ldr;
         # good PEB layout reference here:

--- a/linking/runtime-linking/link-function-at-runtime.yml
+++ b/linking/runtime-linking/link-function-at-runtime.yml
@@ -20,4 +20,4 @@ rule:
         - api: kernel32.GetProcAddress
         - api: ntdll.LdrGetProcedureAddress
       - optional:
-        - characteristic(indirect call): true
+        - characteristic: indirect call

--- a/nursery/get-installed-programs.yml
+++ b/nursery/get-installed-programs.yml
@@ -10,4 +10,4 @@ rule:
     - and:
       - match: open registry key
       - string: /SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall/i
-      - characteristic(loop): true
+      - characteristic: loop

--- a/nursery/hash-data-using-crc32b.yml
+++ b/nursery/hash-data-using-crc32b.yml
@@ -7,4 +7,4 @@ rule:
   features:
     - and:
       - number: 0x4C11DB7
-      - characteristic(nzxor): true
+      - characteristic: nzxor


### PR DESCRIPTION
Get rid of `true` in characteristic as it is implicit.
The changes are the result of executing the following commands:
```
find . -type f -exec sed -i.bak "s/\(.*\)characteristic(\(.*\)): true/\1characteristic: \2/g" {} \;
find . -name "*.bak" -type f -delete
```

Related to https://github.com/fireeye/capa/pull/39