### PR TITLE
Improve capa checkout in sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -28,15 +28,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: update_num_rules
     steps:
+    # Do not checkout submodules as we don't need capa-testfiles and we need to
+    # update the rules submodule reference
     - name: Checkout capa
       uses: actions/checkout@v2
       with:
         repository: fireeye/capa
-        token: ${{ secrets.CAPA_TOKEN }}
-        submodules: true
-    - name: Sync rules submodule
-      run: |
-        git submodule update --remote rules
+    - name: Checkout capa-rules
+      uses: actions/checkout@v2
+      with:
+        path: rules
     - name: Update rules number badge in README
       run: |
         num_rules=$(find rules -type f -name '*.yml' -not -path 'rules/.github/*' | wc -l)


### PR DESCRIPTION
The sync GitHub action seems to be working fine! 🥳  But I have come up with some improvements:
- Do not include `CAPA_TOKEN` token as capa is a public repo and token is not needed for checkout (it tried this out in a private repo)
- [@williballenthin mentioned when this was introduced that it would be nice to not checkout the `tests/data` submodule (as it is big)](https://github.com/fireeye/capa-rules/pull/36#discussion_r454529546). I've discovered [GitHub Action's environment variables](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables), which provides a cool way to not checkout the `tests/data` submodule: checkout only `capa-rules`, which also automatically checkouts the correct version without needing to update the submodule after the checkout (as it uses `$GITHUB_SHA` environment variable).