### PR TITLE
Revert "Improve capa checkout in sync workflow"

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -28,16 +28,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: update_num_rules
     steps:
-    # Do not checkout submodules as we don't need capa-testfiles and we need to
-    # update the rules submodule reference
     - name: Checkout capa
       uses: actions/checkout@v2
       with:
         repository: fireeye/capa
-    - name: Checkout capa-rules
-      uses: actions/checkout@v2
-      with:
-        path: rules
+        token: ${{ secrets.CAPA_TOKEN }}
+        submodules: true
+    - name: Sync rules submodule
+      run: |
+        git submodule update --remote rules
     - name: Update rules number badge in README
       run: |
         num_rules=$(find rules -type f -name '*.yml' -not -path 'rules/.github/*' | wc -l)


### PR DESCRIPTION
Seems like something's off here

Reverts fireeye/capa-rules#40