### PR TITLE
Adding QueryWorkingSet from psapi to be used in ReadProcessMemory rule and second NtQuerySystemInformation rule.

### DIFF
--- a/nursery/enumerate-processes-via-ntquerysysteminformation.yml
+++ b/nursery/enumerate-processes-via-ntquerysysteminformation.yml
@@ -1,0 +1,14 @@
+rule:
+  meta:
+    name: query processes via NtQuerySystemInformation
+    namespace: host-interaction/process/list
+    author: "@_re_fox"
+    scope: basic block
+    att&ck:
+      - Discovery::Process Discovery [T1057]
+    examples:
+      - 31bd8dd48ac0de3d4da340bf29f4d280:0x00401be3
+  features:
+    - and:
+      - number: 0x5 = SYSTEM_PROCESS_INFORMATION
+      - api: ntdll.NtQuerySystemInformation

--- a/nursery/read-process-memory.yml
+++ b/nursery/read-process-memory.yml
@@ -11,3 +11,4 @@ rule:
         - or:
           - api: kernel32.OpenProcess
           - api: kernel32.VirtualQueryEx
+          - api: psapi.QueryWorkingSet


### PR DESCRIPTION
QueryWorkingSet from psapi will also work in a similar fashion to VirtualQueryEx.  

PoC code is on github for using QueryWorkingSet or VirtualQueryEx  -> https://github.com/SpiderLabs/malware-analysis/blob/master/C/queryWorkingSet.c 

A blog post with full instructions can be found here -> https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/new-memory-scraping-technique-in-cherry-picker-pos-malware/

Both calls will ultimately land at NtQueryVirtualMemory.

I'm not sure if there is a process to modify authors of these rules as contributors commit up changes, so I'm leaving the author field as is.