### PR TITLE
Create check-mutex-and-exit.yml

### DIFF
--- a/nursery/check-mutex-and-exit.yml
+++ b/nursery/check-mutex-and-exit.yml
@@ -8,9 +8,7 @@ rule:
       - 1d8fd13c890060464019c0f07b928b1a:0x00402eb0
   features:
     - and:
-        - or:
-          - api: CreateMutex
-          - api: CreateMutexEx
+        - match: create mutex
         - api: GetLastError
         - api: ExitProcess
         - or:

--- a/nursery/check-mutex-and-exit.yml
+++ b/nursery/check-mutex-and-exit.yml
@@ -1,0 +1,19 @@
+rule:
+  meta:
+    name: check mutex and exit
+    namespace: host-interaction/mutex
+    author: "@_re_fox"
+    scope: function
+    examples:
+      - 1d8fd13c890060464019c0f07b928b1a:0x00402eb0
+  features:
+    - and:
+        - or:
+          - api: CreateMutex
+          - api: CreateMutexEx
+        - api: GetLastError
+        - api: ExitProcess
+        - or:
+            - number: 2 = ERROR_FILE_NOT_FOUND
+            - number: 0xb7 = ERROR_ALREADY_EXISTS
+            - number: 5 = ERROR_ACCESS_DENIED


### PR DESCRIPTION
The point of sale malware `1d8fd13c890060464019c0f07b928b1a` will check for the existence of a mutex and bail (`ExitProcess`) if the mutex exists.  This rule will describe that feature.  

Attached is a screenshot of the function, with the error codes the malware will check for (`0xb7 = ERROR_ALREADY_EXISTS` and `5 = ERROR_ACCESS_DENIED`)

![image](https://user-images.githubusercontent.com/57954766/88225765-0b1eee00-cc39-11ea-9bae-ef063c9e44bc.png)

This does create a question though, is this too specific of a rule?  Capa already has a rule for creating a mutex and another rule for checking a mutex, both are similar to my rule.  This is just one extension more to check and see if the program will exit.  

I'm (personally) a proponent of having many specific rules, even if a lot of them overlap with similar features.  Let me know your feedback and I'm happy to make any required changes.  