### PR TITLE
Create credit-card-feature-parsing.yml

### DIFF
--- a/nursery/credit-card-feature-parsing.yml
+++ b/nursery/credit-card-feature-parsing.yml
@@ -1,0 +1,38 @@
+rule:
+  meta:
+    name: credit card feature parsing
+    namespace: collection/credit-card
+    author: "@_re_fox"
+    scope: function
+  examples:
+    - 1d8fd13c890060464019c0f07b928b1a:0x402860
+  features:
+    - 4 or more:
+      - basic block:
+        - and:
+          - mnemonic: cmp
+          - number: 0x5E = '^' (Track 1 separator)
+      - basic block:
+        - and:
+          - mnemonic: cmp
+          - number: 0x3D = '=' (Track 2 separator)
+      - basic block:
+        - and:
+          - mnemonic: cmp
+          - number: 0x25 = '%' (Track 1 start sentinel)
+      - basic block:
+        - and:
+          - mnemonic: cmp
+          - number: 0x42 = 'B' (Format code)
+      - basic block:
+        - and:
+          - mnemonic: cmp
+          - number: 0x44 = 'D' (Format code)
+      - basic block:
+        - and:
+          - mnemonic: cmp
+          - number: 0x3F = '?' (Track 1 & 2 end sentinel)
+      - basic block:
+        - and:
+          - mnemonic: cmp
+          - number: 0x3B = ';' (Track 2 start sentinel)


### PR DESCRIPTION
I've been working through sample `1d8fd13c890060464019c0f07b928b1a` (which was pushed to the testfiles repo) and making sure that rules are triggering on all significant behaviour.

@williballenthin I noticed that you had a credit card rule, but it wasn't triggering on this sample, due to the `read process memory` rule hitting on a different function.  I added in the additional sentinel checks that were performed by this sample and added it as another nursery rule.

Running against the sample will now show 
```
credit card feature parsing
namespace  collection/credit-card
scope      function
matches    0x402860
```