### PR TITLE
Create read-initialization-file.yml

### DIFF
--- a/host-interaction/file-system/read/read-ini-file.yml
+++ b/host-interaction/file-system/read/read-ini-file.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: read ini file
+    name: read .ini file
     namespace: host-interaction/file-system/read
     author: "@_re_fox"
     scope: function

--- a/host-interaction/file-system/read/read-ini-file.yml
+++ b/host-interaction/file-system/read/read-ini-file.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: read .ini file
+    name: read ini file
     namespace: host-interaction/file-system/read
     author: "@_re_fox"
     scope: function

--- a/host-interaction/file-system/read/read-ini-file.yml
+++ b/host-interaction/file-system/read/read-ini-file.yml
@@ -1,11 +1,11 @@
 rule:
   meta:
-    name: read initialization file
+    name: read .ini file
     namespace: host-interaction/file-system/read
     author: "@_re_fox"
     scope: function
-  examples:
-    - 1d8fd13c890060464019c0f07b928b1a:0x401070
+    examples:
+      - 1d8fd13c890060464019c0f07b928b1a:0x401070
   features:
     - and:
       - or:

--- a/host-interaction/file-system/read/read-initialization-file.yml
+++ b/host-interaction/file-system/read/read-initialization-file.yml
@@ -1,0 +1,18 @@
+rule:
+  meta:
+    name: read initialization file
+    namespace: host-interaction/file-system/read
+    author: "@_re_fox"
+    scope: function
+  examples:
+    - 1d8fd13c890060464019c0f07b928b1a:0x401070
+  features:
+    - and:
+      - or:
+        - api: GetPrivateProfileInt
+        - api: GetPrivateProfileString
+        - api: GetPrivateProfileSection
+        - api: GetPrivateProfileSectionNames
+      - string: /\.ini/i
+      - optional:
+        - api: GetFullPathName


### PR DESCRIPTION
Iterating through the features of `1d8fd13c890060464019c0f07b928b1a` already in the `capa-testfiles` repo.  I added in the feature to determine if the malware is reading from an `.ini` file.   In the mentioned hash, the malware reads in `1.ini`.

Here's a screenshot of the basic block responsible for the action:
![image](https://user-images.githubusercontent.com/57954766/88316374-beddb780-cce5-11ea-96e3-ef97b24e1342.png)

I have the rule scoped for `function` right now, but if this causes too many FP's or is error prone, scoping it to `basic block` might make sense.

Per your last comments, I posted directly to ` host-interaction/file-system/read/`, if this rule needs to go to the nursery, I'd be happy to move it there.

Thanks for the help and feedback.

