### PR TITLE
Adding luhn credit card validation routine

### DIFF
--- a/data-manipulation/checksum/luhn/luhn-credit-card-validation.yml
+++ b/data-manipulation/checksum/luhn/luhn-credit-card-validation.yml
@@ -1,0 +1,37 @@
+rule:
+  meta:
+    name: luhn credit card validation
+    namespace: data-manipulation/checksum
+    author: "@_re_fox"
+    scope: function
+    examples:
+      - 1d8fd13c890060464019c0f07b928b1a:0x401920
+      - 60abaef3fda131ffa20df480cb3f8029:0x4048e0
+  features:
+    - and:
+      - basic block:
+        - and:
+          - number: 0x0
+          - number: 0x2
+          - number: 0x4
+          - number: 0x6
+          - number: 0x8
+          - number: 0x1
+          - number: 0x3
+          - number: 0x5
+          - number: 0x7
+          - number: 0x9
+        description: Digital root lookup table
+      - basic block:
+        - and:
+          - number: 0x30
+          - mnemonic: sub
+          description: Conversion of chr to int 
+      - basic block:
+        - and:
+          - mnemonic: idiv
+          - mnemonic: cdq
+          - number: 0xa
+          - optional : 
+            - mnemonic: neg
+          description: Final section returning checkum % 10

--- a/data-manipulation/checksum/luhn/validate-credit-card-number-with-luhn-algorithm.yml
+++ b/data-manipulation/checksum/luhn/validate-credit-card-number-with-luhn-algorithm.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: luhn credit card validation
+    name: validate credit card number with luhn algorithm
     namespace: data-manipulation/checksum
     author: "@_re_fox"
     scope: function


### PR DESCRIPTION
Adding support for the Luhn credit card validation routine as seen in `1d8fd13c890060464019c0f07b928b1a`.  

This is also the variant that is used in the Dexter malware family.  I put luhn's in it's own folder, under checksums, due to there being a couple different common implementations out there.  As I work through more samples, I'll get the rules up for those variants.

An example of running this against the sample will show the following output.
```
luhn credit card validation
namespace  data-manipulation/checksum
author     @_re_fox
scope      function
examples   1d8fd13c890060464019c0f07b928b1a:0x401920, 60abaef3fda131ffa20df480cb3f8029:0x4048e0
function @ 0x4048E0
  and:
    basic block:
      and:
        number: 0x0 @ 0x4048E6, 0x404933
        number: 0x2 @ 0x4048ED
        number: 0x4 @ 0x4048F4
        number: 0x6 @ 0x4048FB
        number: 0x8 @ 0x404902
        number: 0x1 @ 0x404909, 0x40492C
        number: 0x3 @ 0x404910
        number: 0x5 @ 0x404917
        number: 0x7 @ 0x40491E
        number: 0x9 @ 0x404925
    basic block:
      and:
        number: 0x30 @ 0x40497C
        mnemonic: sub @ 0x40497C
    basic block:
      and:
        mnemonic: idiv @ 0x4049AE
        mnemonic: cdq @ 0x4049A8
        number: 0xA @ 0x4049A9
```

I've also ran this against the linter to verify that it compiles :)

```
python2 scripts/lint.py --thorough -v capa-rules/data-manipulation/checksum/luhn/luhn-credit-card-validation.yml
INFO:capa.lint:successfully loaded 4 rules
INFO:capa.lint:collecting potentially referenced samples
DEBUG:capa.lint:luhn credit card validation
DEBUG:viv_utils.idaloader:failed to import IDA Pro modules
DEBUG:viv_utils:vivisect version match: 0.0.20200708
INFO:capa.lint:no suggestions, nice!
```