### PR TITLE
Update validate-credit-card-number-with-luhn-algorithm.yml

### DIFF
--- a/data-manipulation/checksum/luhn/validate-credit-card-number-with-luhn-algorithm.yml
+++ b/data-manipulation/checksum/luhn/validate-credit-card-number-with-luhn-algorithm.yml
@@ -9,6 +9,8 @@ rule:
       - 60abaef3fda131ffa20df480cb3f8029:0x4048e0
   features:
     - and:
+      - match: contain loop
+        description: Iterate over CC digits
       - basic block:
         - and:
           - number: 0x0
@@ -23,10 +25,15 @@ rule:
           - number: 0x9
         description: Digital root lookup table
       - basic block:
-        - and:
-          - number: 0x30
-          - mnemonic: sub
-          description: Conversion of chr to int 
+        - or:
+          - and:
+            - number: 0x30
+            - mnemonic: sub
+            description: Conversion of chr to int (SUB 0x30) 
+          - and:
+            - mnemonic: lea
+            - offset: -0x30
+            description: Conversion of chr to int (LEA REG,[REG+ -0x30])
       - basic block:
         - and:
           - mnemonic: idiv

--- a/data-manipulation/checksum/luhn/validate-credit-card-number-with-luhn-algorithm.yml
+++ b/data-manipulation/checksum/luhn/validate-credit-card-number-with-luhn-algorithm.yml
@@ -35,10 +35,20 @@ rule:
             - offset: -0x30
             description: Conversion of chr to int (LEA REG,[REG+ -0x30])
       - basic block:
-        - and:
-          - mnemonic: idiv
-          - mnemonic: cdq
-          - number: 0xa
-          - optional : 
-            - mnemonic: neg
-          description: Final section returning checkum % 10
+        - or:
+          - and:
+            - mnemonic: idiv
+            - mnemonic: cdq
+            - number: 0xa
+            - optional : 
+              - mnemonic: neg
+            description: Final section returning checkum % 10
+          - and:
+            - mnemonic: shr
+            - mnemonic: imul
+            - number: 0x66666667
+            - number: 0x1f
+            - number: 0x2
+            - optional : 
+              - mnemonic: neg
+            description: Compiler optimized returning checkum % 10 


### PR DESCRIPTION
This is a rule tightening PR.  

Added loop modifier now that https://github.com/fireeye/capa/pull/192 is pulled.  

Added case where a sample (`af13e7583ed1b27c4ae219e344a37e2b`) was using a `lea eax,[eax + -0x30]` rather than a `sub`.

I've tested against multiple POS malware samples and this seems to catch a fair bit of them, I've got some slight modifications that will be coming in the next couple days to support the corner cases.