### PR TITLE
Create change-the-wallpaper.yml

### DIFF
--- a/host-interaction/gui/session/wallpaper/change-the-wallpaper.yml
+++ b/host-interaction/gui/session/wallpaper/change-the-wallpaper.yml
@@ -1,0 +1,13 @@
+rule:
+  meta:
+    name: change the wallpaper
+    namespace: host-interaction/gui/session
+    author: "@_re_fox"
+    scope: basic block
+    examples:
+      - 5dd0b130d5c3d40c69e3972f39fd7d62:0x45AC6F
+  features:
+    - and:
+      - api: SystemParametersInfo
+      - number: 0x14 = SPI_SETDESKWALLPAPER
+      - number: 0x3 = SPIF_SENDWININICHANGE | SPIF_UPDATEINIFILE


### PR DESCRIPTION
This rule will look for the use `SystemParametersInfo` with the constant of `SPI_SETDESKWALLPAPER`.  

I've observed this mostly in ransomware that changes the desktop wallpaper to display instructions.

I'll also open a PR under capa-testfiles to upload `5dd0b130d5c3d40c69e3972f39fd7d62` which is the example program.