### PR TITLE
Create capture-network-configuration-via-ipconfig.yml

### DIFF
--- a/collection/network/capture-network-configuration-via-ipconfig.yml
+++ b/collection/network/capture-network-configuration-via-ipconfig.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: capture network configuration via ipconfig
+    namespace: collection/network
+    author: "@_re_fox"
+    scope: basic block
+    examples:
+      -7204e3efc2434012e13ca939db0d0b02:0x403028
+  features:
+    - and:
+      - string: /ipconfig(\.exe)?/i
+      - api: msvcr100.system
+      - optional:
+        - and:
+          - string: ipconfig.txt
+          - string: /\[Windows IP Configuration\]/
+            description: Arkei Stealer Filename and Banner

--- a/collection/network/capture-network-configuration-via-ipconfig.yml
+++ b/collection/network/capture-network-configuration-via-ipconfig.yml
@@ -5,7 +5,7 @@ rule:
     author: "@_re_fox"
     scope: basic block
     examples:
-      -7204e3efc2434012e13ca939db0d0b02:0x403028
+      - 7204e3efc2434012e13ca939db0d0b02:0x403028
   features:
     - and:
       - string: /ipconfig(\.exe)?/i


### PR DESCRIPTION
Working through the copy of Arkei that was uploaded to `capa-testfiles` (hash: `7204e3efc2434012e13ca939db0d0b02`)

The malware will make a `system` call via the C runtime `msvcr100` to run `ipconfig > ipconfig.txt`.   Seen in the following screenshot.

![image](https://user-images.githubusercontent.com/57954766/88871181-3bd8c780-d1e5-11ea-9f23-1131af825223.png)

When running the rule against the sample it looks like the regex in the `string` returns the last occurrence.  This isn't a problem, it just led to an unexpected result.

Where rather than matching the actual command `ipconfig >ipconfig.txt`, we matched the `ipconfig.txt`.
```
    string: ipconfig.txt @ 0x403043
    api: msvcr100.system @ 0x403035
```
The full results are shown here.  I added in a small description as this rule that can call out the format strings and banners, in the case that anyone will want to use this rule for categorization.  

I can see this rule being built out more (other ways to shell out via ShellExecute, WinExec, etc...)

The full results:
```
capture network configuration via ipconfig
namespace  collection/network
author     @_re_fox
scope      basic block
examples   -7204e3efc2434012e13ca939db0d0b02:0x403028
basic block @ 0x403028
  and:
    string: ipconfig.txt @ 0x403043
    api: msvcr100.system @ 0x403035
    optional:
      and:
        string: ipconfig.txt @ 0x403043
        string: [Windows IP Configuration]
 = Arkei Stealer Filename and Banner @ 0x403028
```
