### PR TITLE
new rules for cabinet file manipulation

### DIFF
--- a/nursery/add-file-to-cabinet-file.yml
+++ b/nursery/add-file-to-cabinet-file.yml
@@ -1,0 +1,10 @@
+rule:
+  meta:
+    name: add file to cabinet file
+    namespace: host-interaction/file-system
+    author: michael.hunhoff@fireeye.com
+    scope: function
+    references: https://docs.microsoft.com/en-us/windows/win32/msi/cabinet-files
+  features:
+    - or:
+      - api: cabinet.FCIAddFile

--- a/nursery/flush-cabinet-file.yml
+++ b/nursery/flush-cabinet-file.yml
@@ -1,0 +1,11 @@
+rule:
+  meta:
+    name: flush cabinet file
+    namespace: host-interaction/file-system
+    author: michael.hunhoff@fireeye.com
+    scope: function
+    references: https://docs.microsoft.com/en-us/windows/win32/msi/cabinet-files
+  features:
+    - or:
+      - api: cabinet.FCIFlushFolder # flush current folder under construction
+      - api: cabinet.FCIFlushCabinet # completes current cabinet

--- a/nursery/open-cabinet-file.yml
+++ b/nursery/open-cabinet-file.yml
@@ -1,0 +1,10 @@
+rule:
+  meta:
+    name: open cabinet file
+    namespace: host-interaction/file-system
+    author: michael.hunhoff@fireeye.com
+    scope: function
+    references: https://docs.microsoft.com/en-us/windows/win32/msi/cabinet-files
+  features:
+    - or:
+      - api: cabinet.FCICreate


### PR DESCRIPTION
Adding new rules to detect manipulation of cabinet (`.cab`) files. Rules placed in nursery until example samples are found.

More information: https://docs.microsoft.com/en-us/windows/win32/msi/cabinet-files