### PR TITLE
Update validate-credit-card-number-with-luhn-algorithm.yml

### DIFF
--- a/data-manipulation/checksum/luhn/validate-credit-card-number-with-luhn-algorithm.yml
+++ b/data-manipulation/checksum/luhn/validate-credit-card-number-with-luhn-algorithm.yml
@@ -12,18 +12,30 @@ rule:
       - match: contain loop
         description: Iterate over CC digits
       - basic block:
-        - and:
-          - number: 0x0
-          - number: 0x2
-          - number: 0x4
-          - number: 0x6
-          - number: 0x8
-          - number: 0x1
-          - number: 0x3
-          - number: 0x5
-          - number: 0x7
-          - number: 0x9
-        description: Digital root lookup table
+        - or:
+          - and:
+            - number: 0x0
+            - number: 0x2
+            - number: 0x4
+            - number: 0x6
+            - number: 0x8
+            - number: 0x1
+            - number: 0x3
+            - number: 0x5
+            - number: 0x7
+            - number: 0x9
+            description: Digital root lookup table
+          - and:
+            - number: 0x0
+            - number: 0x1
+            - number: 0x2
+            - number: 0x3
+            - number: 0x4
+            - number: 0xfffffffc
+            - number: 0xfffffffd
+            - number: 0xfffffffe
+            - number: 0xffffffff
+            description: Digital root lookup table via neg numbers
       - basic block:
         - or:
           - and:


### PR DESCRIPTION
This is the variant of the luhn checksum where the authors used negative numbers as part of the digital root lookup.  This version is used in the sample `ce0296e2d77ec3bb112e270fc260f274`.  I didn't upload this sample to `capa-testfiles` since it's a one off, but I'm able to if it is part of the standard process.

There are some slightly different variants that I have listed that I'll be pushing coverage for in the next couple weeks.

I can refactor the rule to make it a bit more compact, but right now I have each variant of the rule listed so the rule isn't a nightmare to debug or figure out what it is intended to trigger on.