### PR TITLE
Create encrypt-data-using-camellia.yml

### DIFF
--- a/data-manipulation/encryption/camellia/encrypt-data-using-camellia.yml
+++ b/data-manipulation/encryption/camellia/encrypt-data-using-camellia.yml
@@ -1,0 +1,35 @@
+rule:
+  meta:
+    name: encrypt-data-using-camellia
+    namespace: data-manipulation/encryption/camellia
+    author: "@_re_fox"
+    scope: basic block
+    examples: 
+      - 0761142efbda6c4b1e801223de723578:0x6541CD50
+  features:
+    - or:
+      - bytes: 00 70 70 70 00 82 82 82 00 2c 2c 2c 00 ec ec ec 00 b3 b3 b3 00 27 27 27 00 c0 c0 c0 00 e5 e5 e5 00 e4 e4 e4 00 85 85 85 00 57 57 57 00 35 35 35 00 ea ea ea 00 0c 0c 0c 00 ae ae ae 00 41 41 41 00 23 23 23 00 ef ef ef 00 6b 6b 6b 00 93 93 93 00 45 45 45 00 19 19 19 00 a5 a5 a5 00 21 21 21 00 ed ed ed 00 0e 0e 0e 00 4f 4f 4f 00 4e 4e 4e 00 1d 1d 1d 00 65 65 65 00 92 92 92 00 bd bd bd 00 86 86 86 00 b8 b8 b8 00 af af af 00 8f 8f 8f 00 7c 7c 7c 00 eb eb eb 00 1f 1f 1f 00 ce ce ce 00 3e 3e 3e 00 30 30 30 00 dc dc = sp1110
+      - bytes: e0 e0 e0 00 05 05 05 00 58 58 58 00 d9 d9 d9 00 67 67 67 00 4e 4e 4e 00 81 81 81 00 cb cb cb 00 c9 c9 c9 00 0b 0b 0b 00 ae ae ae 00 6a 6a 6a 00 d5 d5 d5 00 18 18 18 00 5d 5d 5d 00 82 82 82 00 46 46 46 00 df df df 00 d6 d6 d6 00 27 27 27 00 8a 8a 8a 00 32 32 32 00 4b 4b 4b 00 42 42 42 00 db db db 00 1c 1c 1c 00 9e 9e 9e 00 9c 9c 9c 00 3a 3a 3a 00 ca ca ca 00 25 25 25 00 7b 7b 7b 00 0d 0d 0d 00 71 71 71 00 5f 5f 5f 00 1f 1f 1f 00 f8 f8 f8 00 d7 d7 d7 00 3e 3e 3e 00 9d 9d 9d 00 7c 7c 7c 00 60 60 60 00 b9 b9 b9 = sp0222
+      - bytes: 38 38 00 38 41 41 00 41 16 16 00 16 76 76 00 76 d9 d9 00 d9 93 93 00 93 60 60 00 60 f2 f2 00 f2 72 72 00 72 c2 c2 00 c2 ab ab 00 ab 9a 9a 00 9a 75 75 00 75 06 06 00 06 57 57 00 57 a0 a0 00 a0 91 91 00 91 f7 f7 00 f7 b5 b5 00 b5 c9 c9 00 c9 a2 a2 00 a2 8c 8c 00 8c d2 d2 00 d2 90 90 00 90 f6 f6 00 f6 07 07 00 07 a7 a7 00 a7 27 27 00 27 8e 8e 00 8e b2 b2 00 b2 49 49 00 49 de de 00 de 43 43 00 43 5c 5c 00 5c d7 d7 00 d7 c7 c7 00 c7 3e 3e 00 3e f5 f5 00 f5 8f 8f 00 8f 67 67 00 67 1f 1f 00 1f 18 18 00 18 6e 6e 00 = sp3033
+      - bytes: 70 00 70 70 2c 00 2c 2c b3 00 b3 b3 c0 00 c0 c0 e4 00 e4 e4 57 00 57 57 ea 00 ea ea ae 00 ae ae 23 00 23 23 6b 00 6b 6b 45 00 45 45 a5 00 a5 a5 ed 00 ed ed 4f 00 4f 4f 1d 00 1d 1d 92 00 92 92 86 00 86 86 af 00 af af 7c 00 7c 7c 1f 00 1f 1f 3e 00 3e 3e dc 00 dc dc 5e 00 5e 5e 0b 00 0b 0b a6 00 a6 a6 39 00 39 39 d5 00 d5 d5 5d 00 5d 5d d9 00 d9 d9 5a 00 5a 5a 51 00 51 51 6c 00 6c 6c 8b 00 8b 8b 9a 00 9a 9a fb 00 fb fb b0 00 b0 b0 74 00 74 74 2b 00 2b 2b f0 00 f0 f0 84 00 84 84 df 00 df df cb 00 cb cb 34 00 34 = sp4404
+      - or:
+        - and:
+          - number: 0x3bcc908b
+          - number: 0xa09e667f
+          - number: 0x4caa73b2
+          - number: 0xb67ae858
+          - number: 0xc6ef372f
+          - number: 0xe94f82be
+          - number: 0x54ff53a5
+          - number: 0xf1d36f1c
+          - number: 0x10e527fa
+          - number: 0xde682d1d
+          - number: 0xb05688c2
+          - number: 0xb3e6c1fd
+        - and:
+          - bytes: 8b 90 cc 3b 7f 66 9e a0 = sigma1
+          - bytes: b2 73 aa 4c 58 e8 7a b6 = sigma2
+          - bytes: be 82 4f e9 2f 37 ef c6 = sigma3
+          - bytes: 1c 6f d3 f1 a5 53 ff 54 = sigma4
+          - bytes: 1d 2d 68 de fa 27 e5 10 = sigma5
+          - bytes: fd c1 e6 b3 c2 88 56 b0 = sigma6


### PR DESCRIPTION
This rule covers the Camellia cipher covered here -> https://github.com/gpg/libgcrypt/blob/355f5b7f69075c010fe33aa5b10ac60c08fae0c7/cipher/camellia.c .  I'll upload the sample to capa-testfiles and I have a couple more planned rules off that sample.  Rather than uploading them in bulk, I'll post them up one at a time for review to make the PR's a bit more painless.

The tables are larger than what capa allows (large tables of DWORDs) so I converted them to bytes and truncated at a 256 cutoff.  