### PR TITLE
Create encrypt-data-using-blowfish.yml

### DIFF
--- a/data-manipulation/encryption/blowfish/encrypt-data-using-blowfish.yml
+++ b/data-manipulation/encryption/blowfish/encrypt-data-using-blowfish.yml
@@ -1,0 +1,21 @@
+rule:
+  meta:
+    name: encrypt data using blowfish
+    namespace: data-manipulation/encryption/blowfish
+    author: "@_re_fox"
+    scope: basic block
+    examples: 
+      - 0761142efbda6c4b1e801223de723578:0x653E19E5
+  features:
+    - or:
+      - and:
+        - number: 0x3a39ce37 = u32 ks3 sbox4
+        - number: 0xe93d5a68 = u32 ks2 sbox3
+        - number: 0x4b7a70e9 = u32 ks1 sbox2
+        - number: 0xd1310ba6 = u32 ks0 sbox1
+      - or:
+        - bytes: 88 6a 3f 24 d3 08 a3 85 2e 8a 19 13 44 73 70 03 22 38 09 a4 d0 31 9f 29 98 fa 2e 08 89 6c 4e ec e6 21 28 45 77 13 d0 38 cf 66 54 be 6c 0c e9 34 b7 29 ac c0 dd 50 7c c9 b5 d5 84 3f 17 09 47 b5 d9 d5 16 92 1b fb 79 89 = ps
+        - bytes: a6 0b 31 d1 ac b5 df 98 db 72 fd 2f b7 df 1a d0 ed af e1 b8 96 7e 26 6a 45 90 7c ba 99 7f 2c f1 47 99 a1 24 f7 6c 91 b3 e2 f2 01 08 16 fc 8e 85 d8 20 69 63 69 4e 57 71 a3 fe 58 a4 7e 3d 93 f4 8f 74 95 0d 58 b6 8e 72 58 cd 8b 71 ee 4a 15 82 1d a4 54 7b b5 59 5a c2 39 d5 30 9c 13 60 f2 2a 23 b0 d1 c5 f0 85 60 28 18 79 41 ca ef 38 db b8 b0 dc 79 8e 0e 18 3a 60 8b 0e 9e 6c 3e 8a 1e b0 c1 77 15 d7 27 4b 31 bd da 2f af 78 60 5c 60 55 f3 25 55 e6 94 ab 55 aa 62 98 48 57 40 14 e8 63 6a 39 ca 55 b6 10 ab 2a 34 5c cc = ks0 sbox1
+        - bytes: e9 70 7a 4b 44 29 b3 b5 2e 09 75 db 23 26 19 c4 b0 a6 6e ad 7d df a7 49 b8 60 ee 9c 66 b2 ed 8f 71 8c aa ec ff 17 9a 69 6c 52 64 56 e1 9e b1 c2 a5 02 36 19 29 4c 09 75 40 13 59 a0 3e 3a 18 e4 9a 98 54 3f 65 9d 42 5b d6 e4 8f 6b d6 3f f7 99 07 9c d2 a1 f5 30 e8 ef e6 38 2d 4d c1 5d 25 f0 86 20 dd 4c 26 eb 70 84 c6 e9 82 63 5e cc 1e 02 3f 6b 68 09 c9 ef ba 3e 14 18 97 3c a1 70 6a 6b 84 35 7f 68 86 e2 a0 52 05 53 9c b7 37 07 50 aa 1c 84 07 3e 5c ae de 7f ec 44 7d 8e b8 f2 16 57 37 da 3a b0 0d 0c 50 f0 04 1f 1c  = ks1 sbox2
+        - bytes: 68 5a 3d e9 f7 40 81 94 1c 26 4c f6 34 29 69 94 f7 20 15 41 f7 d4 02 76 2e 6b f4 bc 68 00 a2 d4 71 24 08 d4 6a f4 20 33 b7 d4 b7 43 af 61 00 50 2e f6 39 1e 46 45 24 97 74 4f 21 14 40 88 8b bf 1d fc 95 4d af 91 b5 96 d3 dd f4 70 45 2f a0 66 ec 09 bc bf 85 97 bd 03 d0 6d ac 7f 04 85 cb 31 b3 27 eb 96 41 39 fd 55 e6 47 25 da 9a 0a ca ab 25 78 50 28 f4 29 04 53 da 86 2c 0a fb 6d b6 e9 62 14 dc 68 00 69 48 d7 a4 c0 0e 68 ee 8d a1 27 a2 fe 3f 4f 8c ad 87 e8 06 e0 8c b5 b6 d6 f4 7a 7c 1e ce aa ec 5f 37 d3 99 a3 78 = ks2 sbox3
+        - bytes: 37 ce 39 3a cf f5 fa d3 37 77 c2 ab 1b 2d c5 5a 9e 67 b0 5c 42 37 a3 4f 40 27 82 d3 be 9b bc 99 9d 8e 11 d5 15 73 0f bf 7e 1c 2d d6 7b c4 00 c7 6b 1b 8c b7 45 90 a1 21 be b1 6e b2 b4 6e 36 6a 2f ab 48 57 79 6e 94 bc d2 76 a3 c6 c8 c2 49 65 ee f8 0f 53 7d de 8d 46 1d 0a 73 d5 c6 4d d0 4c db bb 39 29 50 46 ba a9 e8 26 95 ac 04 e3 5e be f0 d5 fa a1 9a 51 2d 6a e2 8c ef 63 22 ee 86 9a b8 c2 89 c0 f6 2e 24 43 aa 03 1e a5 a4 d0 f2 9c ba 61 c0 83 4d 6a e9 9b 50 15 e5 8f d6 5b 64 ba f9 a2 26 28 e1 3a 3a a7 86 95 a9 = ks3 sbox4


### PR DESCRIPTION
Adding in support for blowfish as seen in libgcrypt -> https://github.com/gpg/libgcrypt/blob/master/cipher/blowfish.c

SBoxes are truncated at 256 bytes.