### PR TITLE
Create check-if-process-is-running-under-wine.yml

### DIFF
--- a/anti-analysis/anti-emulation/wine/check-if-process-is-running-under-wine.yml
+++ b/anti-analysis/anti-emulation/wine/check-if-process-is-running-under-wine.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: check if process is running under wine
+    namespace: anti-analysis/anti-emulation/wine
+    author: "@_re_fox"
+    scope: function
+    examples:
+      - ccbf7cba35bab56563c0fbe4237fdc41:0x40d750
+  features:
+    - and:
+      - api: GetModuleHandle
+      - api: GetProcAddress
+      - string: wine_get_unix_file_name
+      - or:
+        - string: kernel32.dll
+        - string: ntdll.dll


### PR DESCRIPTION
Reference -> https://www.hexacorn.com/blog/2016/03/27/detecting-wine-via-internal-and-legacy-apis/

This is a rule that looks for the following logic (from a decompiled snippet) which is checking for the presence of a wine export name.

```c
  hModule = GetModuleHandleA("kernel32.dll");
  if (hModule == (HMODULE)0x0) {
    uVar2 = 1;
  }
  else {
    pFVar1 = GetProcAddress(hModule,"wine_get_unix_file_name");
    if (pFVar1 == (FARPROC)0x0) {
      uVar2 = 1;
    }
    else {
      uVar2 = 0;
    }
  }
  return uVar2;
```

Let me know if the namespacing is OK on this rule, I put it in a new directory under `anti-analysis/anti-emulation/wine`.  I figured that there will be other emulation checks for other emulation frameworks.  

I made a PR in capa-testfiles with the file in the example.