### PR TITLE
Create check-for-sandbox-and-av-modules.yml

### DIFF
--- a/anti-analysis/anti-av/check-for-sandbox-and-av-modules.yml
+++ b/anti-analysis/anti-av/check-for-sandbox-and-av-modules.yml
@@ -1,0 +1,40 @@
+rule:
+  meta:
+    name: check for sandbox and av modules
+    namespace: anti-analysis/anti-vm/
+    author: "@_re_fox"
+    scope: basic block
+    examples:
+      - ccbf7cba35bab56563c0fbe4237fdc41:0x0040a4a0
+  features:
+    - and:
+      - api: GetModuleHandle
+      - or:
+        - string: /avghook(x|a)\.dll/i
+          description: AVG
+        - string: /snxhk\.dll/i 
+          description: Avast
+        - string: /sf2\.dll/i 
+          description: Avast
+        - string: /sbiedll\.dll/i
+          description: Sandboxie
+        - string: /dbghelp\.dll/i 
+          description: WindBG
+        - string: /api_log\.dll/i 
+          description: iDefense Lab
+        - string: /dir_watch\.dll/ 
+          description: iDefense Lab
+        - string: /pstorec\.dll/i
+          description: SunBelt Sandbox
+        - string: /vmcheck\.dll/i
+          description: Virtual PC
+        - string: /wpespy\.dll/i
+          description: WPE Pro
+        - string: /cmdvrt(64|32).dll/i 
+          description: Comodo Container
+        - string: /sxin.dll/i 
+          description: 360 SOFTWARE
+        - string: /dbghelp\.dll/i
+          description: WINE
+        - string: /printfhelp\.dll/i 
+          descrtipion: Unknown Sandbox

--- a/anti-analysis/anti-av/check-for-sandbox-and-av-modules.yml
+++ b/anti-analysis/anti-av/check-for-sandbox-and-av-modules.yml
@@ -1,7 +1,7 @@
 rule:
   meta:
     name: check for sandbox and av modules
-    namespace: anti-analysis/anti-vm
+    namespace: anti-analysis/anti-av
     author: "@_re_fox"
     scope: basic block
     examples:

--- a/anti-analysis/anti-av/check-for-sandbox-and-av-modules.yml
+++ b/anti-analysis/anti-av/check-for-sandbox-and-av-modules.yml
@@ -1,7 +1,7 @@
 rule:
   meta:
     name: check for sandbox and av modules
-    namespace: anti-analysis/anti-vm/
+    namespace: anti-analysis/anti-vm
     author: "@_re_fox"
     scope: basic block
     examples:


### PR DESCRIPTION
Simple rule looking for known sandbox and AV dlls.  

In most samples that I've looked at, the function will resemble the following 
![image](https://user-images.githubusercontent.com/57954766/90088096-3783d280-dcec-11ea-93c2-67f751fa0f75.png)

Check if any exist and jump out if it finds one.  Calling GetModuleHandle at each basic block.

I also took a list from https://github.com/LordNoteworthy/al-khaser/blob/8c7a5f378617e01f28844a3ec7543eda7731abf4/al-khaser/AntiVM/Generic.cpp#L14 and combined it to cover most variations.

I know that not *all* of them are AV, but since most of them are, it felt like the best place to store this was under `anti-av`.  Let me know if this needs to be broken up into different sandboxes and placed into different directories, etc..

Thanks!
