### PR TITLE
Create check-for-sandbox-username.yml

### DIFF
--- a/anti-analysis/anti-vm/vm-detection/check-for-sandbox-username.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-sandbox-username.yml
@@ -1,0 +1,60 @@
+rule:
+  meta:
+    name: check for sandbox username
+    namespace: anti-analysis/anti-vm
+    author: "@_re_fox"
+    scope: function
+    examples:
+      - ccbf7cba35bab56563c0fbe4237fdc41:0x402B90
+  features:
+    - and:
+      - api: GetUserName
+      - or:
+        - string: /MALTEST/i
+          description: Betabot Username Check  
+        - string: /TEQUILABOOMBOOM/i
+          description: VirusTotal Sandbox
+        - string: /SANDBOX/i
+          description: Gookit Username Check 
+        - string: /^VIRUS/i
+          description: Satan Username Check
+        - string: /MALWARE/i
+          description: Betabot Username Check
+        - string: /SAND\sBOX/i
+          description: Betabot Username Check
+        - string: /Test\sUser/i
+          description: Betabot Username Check
+        - string: /CurrentUser/i
+          description: Gookit Username Check 
+        - string: /7SILVIA/i
+          description: Gookit Username Check 
+        - string: /FORTINET/i
+          description: Shifu Username Check
+        - string: /John\sDoe/i
+          description: Emotet Username Check
+        - string: /Emily/i
+          description: Trickbot Downloader Username Check 
+        - string: /HANSPETER\-PC/i
+          description: Trickbot Downloader Username Check 
+        - string: /HAPUBWS/i
+          description: Trickbot Downloader Username Check 
+        - string: /Hong\sLee/i
+          description: Trickbot Downloader Username Check 
+        - string: /IT\-ADMIN/i
+          description: Trickbot Downloader Username Check 
+        - string: /JOHN\-PC/i
+          description: Trickbot Downloader Username Check
+        - string: /Johnson/i
+          description: Trickbot Downloader Username Check 
+        - string: /Miller/i
+          description: Trickbot Downloader Username Check 
+        - string: /MUELLER\-PC/i
+          description: Trickbot Downloader Username Check 
+        - string: /Peter\sWilson/i
+          description: Trickbot Downloader Username Check
+        - string: /SystemIT/i
+          description: Trickbot Downloader Username Check 
+        - string: /Timmy/i
+          description: Trickbot Downloader Username Check 
+        - string: /WIN7\-TRAPS/i
+          description: Trickbot Downloader Username Check 

--- a/anti-analysis/anti-vm/vm-detection/check-for-sandbox-username.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-sandbox-username.yml
@@ -1,7 +1,7 @@
 rule:
   meta:
     name: check for sandbox username
-    namespace: anti-analysis/anti-vm
+    namespace: anti-analysis/anti-vm/vm-detection
     author: "@_re_fox"
     scope: function
     examples:


### PR DESCRIPTION
This is a check for known sandbox user names.  

Some of the usernames were borrowed directly from `ccbf7cba35bab56563c0fbe4237fdc41` in the capa-testfiles repo.  The other usernames were gathered from this issue `al-khaser` -> https://github.com/LordNoteworthy/al-khaser/issues/189

I documented each username and which malware family it was attributed back to, but some of these are generic and probably span multiple families.  If this causes confusion, I can remove the descriptions.  