### PR TITLE
Create compiled-with-py2exe.yml

### DIFF
--- a/compiler/py2exe/compiled-with-py2exe.yml
+++ b/compiler/py2exe/compiled-with-py2exe.yml
@@ -1,0 +1,12 @@
+rule:
+  meta:
+    name: compiled with py2exe
+    namespace: compiler/py2exe
+    author: "@_re_fox"
+    scope: basic block
+    examples:
+      - ed888dc2f04f5eac83d6d14088d002de:0x40194A
+  features:
+    - and:
+      - string: PY2EXE_VERBOSE
+      - api: getenv 


### PR DESCRIPTION
Creating a rule to trigger on py2exe samples.  The sample in the rule has been uploaded to `capa-testfiles`.

It's a start to covering  https://github.com/fireeye/capa-rules/issues/11