### PR TITLE
Create references-logon-banner.yml

### DIFF
--- a/host-interaction/gui/logon/references-logon-banner.yml
+++ b/host-interaction/gui/logon/references-logon-banner.yml
@@ -1,0 +1,14 @@
+rule:
+  meta:
+    name: references logon banner
+    namespace: host-interaction/gui/logon
+    author: "@_re_fox"
+    scope: basic block
+    examples:
+      - c3341b7dfbb9d43bca8c812e07b4299f:0x4066FC
+  features:
+    - and:
+      - string: /\\Microsoft\\Windows\\CurrentVersion\\Policies\\System/
+      - or:
+        - string: /LegalNoticeCaption/
+        - string: /LegalNoticeText/


### PR DESCRIPTION
Apologies on the earlier direct commit.  Mistake.

I recently was looking at a rust exe that changes the Windows logon banner.  The strings referencing the registry keys are passed to a function that modifies the keys so I can't tighten it down too much more.

Since the sample is in rust, the strings are not nice null terminated string.  It has to match a substring in a larger blob.  I'll upload the sample to test-files as well.