### PR TITLE
Update persist-via-run-registry-key.yml

### DIFF
--- a/persistence/registry/run/persist-via-run-registry-key.yml
+++ b/persistence/registry/run/persist-via-run-registry-key.yml
@@ -8,16 +8,21 @@ rule:
       - Persistence::Boot or Logon Autostart Execution::Registry Run Keys / Startup Folder [T1547.001]
     examples:
       - Practical Malware Analysis Lab 06-03.exe_:0x401130
+      - b87e9dd18a5533a09d3e48a7a1efbcf6:0x1400070E0
   features:
-    - and:
-      - or:
+    - or:
+      - and:
         - or:
-          - api: advapi32.RegOpenKey
-          - api: advapi32.RegOpenKeyEx
-        - or:
-          - api: advapi32.RegSetValue
-          - api: advapi32.RegSetValueEx
-        - or:
-          - number: 0x80000001 = HKEY_CURRENT_USER
-          - number: 0x80000002 = HKEY_LOCAL_MACHINE
-      - string: /Software\\Microsoft\\Windows\\CurrentVersion\\Run/i
+          - or:
+            - api: advapi32.RegOpenKey
+            - api: advapi32.RegOpenKeyEx
+          - or:
+            - api: advapi32.RegSetValue
+            - api: advapi32.RegSetValueEx
+          - or:
+            - number: 0x80000001 = HKEY_CURRENT_USER
+            - number: 0x80000002 = HKEY_LOCAL_MACHINE
+        - string: /Software\\Microsoft\\Windows\\CurrentVersion\\Run/i
+      - and:
+        - match: create process
+        - string: /REG ADD[\s\"\\a-z_]{5,20}Software\\Microsoft\\Windows\\CurrentVersion\\Run/i


### PR DESCRIPTION
Ryuk uses a command line string (via `reg add`) to add persistence.  Rather than build a new rule, it felt appropriate to add it to the existing rule targeting Run keys.

Running it on the sample will show the following.  I like how the the full string is returned in the results.  

```
persist via Run registry key
namespace  persistence/registry/run
author     moritz.raabe@fireeye.com
scope      function
att&ck     Persistence::Boot or Logon Autostart Execution::Registry Run Keys / Startup Folder [T1547.001]
examples   Practical Malware Analysis Lab 06-03.exe_:0x401130
function @ 0x1400070E0
  or:
    and:
      match: create process @ 0x1400073B2
        or:
          api: shell32.ShellExecute @ 0x1400073C9
      string: /C REG ADD "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run" /v "svchos" /t REG_SZ /d  @ 0x1400071C3
```