### PR TITLE
Initial set of packer rules

### DIFF
--- a/anti-analysis/packer/peshield/packed-with-peshield.yml
+++ b/anti-analysis/packer/peshield/packed-with-peshield.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: packed with peshield
+    namespace: anti-analysis/packer/peshield
+    author: "@_re_fox"
+    scope: file
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
+    mbc:
+      - Anti-Static Analysis::Software Packing [F0001]
+    examples:
+      - a3c0a2425ea84103adde03a92176424c
+  features:
+    - or:
+      - section: PESHiELD
+      - section: PESHiELD_1
+      - string: / PE-SHiELD v[0-9]\.[0-9]/

--- a/anti-analysis/packer/petite/packed-with-petite.yml
+++ b/anti-analysis/packer/petite/packed-with-petite.yml
@@ -1,0 +1,15 @@
+rule:
+  meta:
+    name: packed with petite
+    namespace: anti-analysis/packer/petite
+    author: "@_re_fox"
+    scope: file
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
+    mbc:
+      - Anti-Static Analysis::Software Packing [F0001]
+    examples:
+      - 2a7429d60040465f9bd27bbae2beef88
+  features:
+    - or:
+      - section: .petite

--- a/anti-analysis/packer/rlpack/packed-with-rlpack.yml
+++ b/anti-analysis/packer/rlpack/packed-with-rlpack.yml
@@ -1,0 +1,15 @@
+rule:
+  meta:
+    name: packed with rlpack
+    namespace: anti-analysis/packer/rlpack
+    author: "@_re_fox"
+    scope: file
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
+    mbc:
+      - Anti-Static Analysis::Software Packing [F0001]
+    examples:
+      - 068a76d4823419b376d418cf03215d5c
+  features:
+    - or:
+      - section: .RLPack

--- a/anti-analysis/packer/upack/packed-with-upack.yml
+++ b/anti-analysis/packer/upack/packed-with-upack.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: packed with upack
+    namespace: anti-analysis/packer/upack
+    author: "@_re_fox"
+    scope: file
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
+    mbc:
+      - Anti-Static Analysis::Software Packing [F0001]
+    examples:
+      - 9d98f8519d9fee8219caca5b31eef0bd
+  features:
+    - and:
+      - section: .Upack
+      - string: UpackByDwing@

--- a/anti-analysis/packer/y0da/packed-with-y0da-crypter.yml
+++ b/anti-analysis/packer/y0da/packed-with-y0da-crypter.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: packed with y0da crypter
+    namespace: anti-analysis/packer/y0da
+    author: "@_re_fox"
+    scope: file
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
+    mbc:
+      - Anti-Static Analysis::Software Packing [F0001]
+    examples:
+      - 0cd2b334aede270b14868db28211cde3
+  features:
+    - or:
+      - section: .y0da
+      - section: .y0da_1


### PR DESCRIPTION
Handful of packer rules based on section names or strings.  

Submitting for cursory detection, the rules could be made more resilient with function features.  All supporting files are in https://github.com/fireeye/capa-testfiles/pull/25