### PR TITLE
add rules describing hardcoded DNS servers

### DIFF
--- a/nursery/reference-114dns-dns-server.yml
+++ b/nursery/reference-114dns-dns-server.yml
@@ -1,0 +1,19 @@
+rule:
+  meta:
+    name: reference 114DNS DNS server
+    namespace: communication/dns
+    author: william.ballenthin@fireeye.com
+    scope: function
+    references:
+      - https://www.114dns.com/
+      - https://www.amazon.com/ask/questions/Tx27CUHKMM403NP
+    examples:
+      # - ab57d3c179355bf2bcdb7935483d84d4
+  features:
+    - or:
+      - string: 114.114.114.114
+      - string: 114.114.115.115
+      - string: 114.114.114.119
+      - string: 114.114.115.119
+      - string: 114.114.114.110
+      - string: 114.114.115.110

--- a/nursery/reference-alidns-dns-server.yml
+++ b/nursery/reference-alidns-dns-server.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: reference AliDNS DNS server
+    namespace: communication/dns
+    author: william.ballenthin@fireeye.com
+    scope: function
+    references:
+      - https://www.alidns.com/
+    examples:
+      # - ab57d3c179355bf2bcdb7935483d84d4
+  features:
+    - or:
+      - string: 223.5.5.5
+      - string: 223.6.6.6
+      - string: 2400:3200::1
+      - string: 2400:3200:baba::1

--- a/nursery/reference-cloudflare-dns-server.yml
+++ b/nursery/reference-cloudflare-dns-server.yml
@@ -1,0 +1,13 @@
+rule:
+  meta:
+    name: reference Cloudflare DNS server
+    namespace: communication/dns
+    author: william.ballenthin@fireeye.com
+    scope: function
+    references:
+      - https://www.techradar.com/news/best-dns-server
+    examples:
+  features:
+    - or:
+      - string: 1.1.1.1
+      - string: 1.0.0.1

--- a/nursery/reference-comodo-secure-dns-server.yml
+++ b/nursery/reference-comodo-secure-dns-server.yml
@@ -1,0 +1,13 @@
+rule:
+  meta:
+    name: reference Comodo Secure DNS server
+    namespace: communication/dns
+    author: william.ballenthin@fireeye.com
+    scope: function
+    references:
+      - https://www.techradar.com/news/best-dns-server
+    examples:
+  features:
+    - or:
+      - string: 8.26.56.26
+      - string: 8.20.247.20

--- a/nursery/reference-google-public-dns-server.yml
+++ b/nursery/reference-google-public-dns-server.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: reference Google Public DNS server
+    namespace: communication/dns
+    author: william.ballenthin@fireeye.com
+    scope: function
+    references:
+      - https://www.techradar.com/news/best-dns-server
+      - https://developers.google.com/speed/public-dns/docs/using
+    examples:
+  features:
+    - or:
+      - string: 8.8.8.8
+      - string: 8.8.4.4
+      - string: 2001:4860:4860::8888
+      - string: 2001:4860:4860::8844

--- a/nursery/reference-hurricane-electric-dns-server.yml
+++ b/nursery/reference-hurricane-electric-dns-server.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: reference Hurricane Electric DNS server
+    namespace: communication/dns
+    author: william.ballenthin@fireeye.com
+    scope: function
+    references:
+      - https://dns.he.net/
+      - https://dnslytics.com/ip/216.66.1.2
+    examples:
+  features:
+    - or:
+      - string: 216.218.130.2
+        description: ns1.he.net
+      - string: 216.218.131.2
+        description: ns2.he.net
+      - string: 216.218.132.2
+        description: ns3.he.net
+      - string: 216.66.1.2
+        description: ns4.he.net
+      - string: 216.66.80.18
+        description: ns5.he.net

--- a/nursery/reference-kornet-dns-server.yml
+++ b/nursery/reference-kornet-dns-server.yml
@@ -1,0 +1,14 @@
+rule:
+  meta:
+    name: reference kornet DNS server
+    namespace: communication/dns
+    author: william.ballenthin@fireeye.com
+    scope: function
+    references:
+      - https://whatismyipaddress.com/ip/168.126.63.1
+    examples:
+      # - ab57d3c179355bf2bcdb7935483d84d4
+  features:
+    - or:
+      - string: 168.126.63.1
+        description: kns.kornet.net

--- a/nursery/reference-l3-dns-server.yml
+++ b/nursery/reference-l3-dns-server.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: reference L3 DNS server
+    namespace: communication/dns
+    author: william.ballenthin@fireeye.com
+    scope: function
+    references:
+      - https://www.quora.com/What-is-a-4-2-2-1-DNS-server
+    examples:
+  features:
+    - or:
+      - string: 4.2.2.1
+      - string: 4.2.2.2
+      - string: 4.2.2.3
+      - string: 4.2.2.4
+      - string: 4.2.2.5
+      - string: 4.2.2.6

--- a/nursery/reference-opendns-dns-server.yml
+++ b/nursery/reference-opendns-dns-server.yml
@@ -1,0 +1,13 @@
+rule:
+  meta:
+    name: reference OpenDNS DNS server
+    namespace: communication/dns
+    author: william.ballenthin@fireeye.com
+    scope: function
+    references:
+      - https://www.techradar.com/news/best-dns-server
+    examples:
+  features:
+    - or:
+      - string: 208.67.222.222
+      - string: 208.67.220.220

--- a/nursery/reference-quad9-dns-server.yml
+++ b/nursery/reference-quad9-dns-server.yml
@@ -1,0 +1,13 @@
+rule:
+  meta:
+    name: reference Quad9 DNS server
+    namespace: communication/dns
+    author: william.ballenthin@fireeye.com
+    scope: function
+    references:
+      - https://www.techradar.com/news/best-dns-server
+    examples:
+  features:
+    - or:
+      - string: 9.9.9.9
+      - string: 149.112.112.112

--- a/nursery/reference-verisign-dns-server.yml
+++ b/nursery/reference-verisign-dns-server.yml
@@ -1,0 +1,13 @@
+rule:
+  meta:
+    name: reference Verisign DNS server
+    namespace: communication/dns
+    author: william.ballenthin@fireeye.com
+    scope: function
+    references:
+      - https://www.techradar.com/news/best-dns-server
+    examples:
+  features:
+    - or:
+      - string: 64.6.64.6
+      - string: 64.6.65.6


### PR DESCRIPTION
initially wanted to describe behavior of this TIGERPLUG dropper here: https://www.virustotal.com/gui/file/784ceff596d94ef365ae261ae43a83c43d52e04dc46b09a8fb5960772bca4a00/content/strings

but the DNS servers are not referenced directly by the dropper, and i haven't gotten around to extracting the payloads.