### PR TITLE
Update check-for-sandbox-username.yml

### DIFF
--- a/anti-analysis/anti-vm/vm-detection/check-for-sandbox-username.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-sandbox-username.yml
@@ -60,3 +60,5 @@ rule:
           description: Trickbot Downloader Username Check
         - string: /WIN7\-TRAPS/i
           description: Trickbot Downloader Username Check
+        - string: /WDAGUtilityAccount/i
+          description: Windows Defender Application Guard


### PR DESCRIPTION
Updating sandbox usernames

Ref: https://github.com/fireeye/capa-rules/issues/162

Rather than writing a new rule, the functionality seems to fit in this existing rule.

This only covers one of the functions listed in `detect.c` from `wsb-detect`

```c
#define SANDBOX_USER L"WDAGUtilityAccount"
````

```c
BOOL wsb_detect_username(VOID)
{
    WCHAR wcUser[UNLEN + 1];
    RtlSecureZeroMemory(wcUser, sizeof(wcUser));

    DWORD dwLength = (UNLEN + 1);
    if (GetUserNameW(wcUser, &dwLength))
    {
        return (wcscmp(wcUser, SANDBOX_USER) == 0);
    }

    return FALSE;
}
```
