### PR TITLE
Create check-for-microsoft-office-emulation.yml

### DIFF
--- a/anti-analysis/anti-vm/vm-detection/check-for-microsoft-office-emulation.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-microsoft-office-emulation.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: check for microsoft office emulation
+    namespace: anti-analysis/anti-vm/vm-detection
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
+    mbc:
+      - Anti-Behavioral Analysis::Virtual Machine Detection::Product Key/ID Testing [B0007.005]
+    references:
+      - https://github.com/LloydLabs/wsb-detect
+    examples:
+      - 773290480d5445f11d3dc1b800728966:0x140001140
+  features:
+    - and:
+      - string: /OfficePackagesForWDAG/
+      - api: GetWindowsDirectory
+      - optional: 
+        - api: CreateFile


### PR DESCRIPTION
Ref: https://github.com/fireeye/capa-rules/issues/162

Will fail to trigger due to https://github.com/fireeye/capa/issues/353

Intended to hit on the following code:

```c
#define SANDBOX_WD_OFFICE_FMT L"%s:\\\\OfficePackagesForWDAG"
```

```c
BOOL wsb_detect_office(VOID)
{
    WCHAR wcDir[MAX_PATH + 1];
    RtlSecureZeroMemory(wcDir, sizeof(wcDir));

    if (GetWindowsDirectoryW(wcDir, MAX_PATH) == 0)
    {
        return FALSE;
    }

    WCHAR wcPath[MAX_PATH + 1];
    RtlSecureZeroMemory(wcPath, sizeof(wcPath));
    if (StringCbPrintfW(wcPath, sizeof(wcPath), SANDBOX_WD_OFFICE_FMT, wcDir) != S_OK)
    {
        return FALSE;
    }

    return util_path_exists(wcPath, 0);
}
```