### PR TITLE
Create check-for-windows-sandbox-via-device.yml

### DIFF
--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-device.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-device.yml
@@ -1,0 +1,18 @@
+rule:
+  meta:
+    name: check for windows sandbox via device
+    namespace: anti-analysis/anti-vm/vm-detection
+    author: "@_re_fox"
+    scope: basic block
+    att&ck:
+      - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
+    mbc:
+      - Anti-Behavioral Analysis::Virtual Machine Detection [B0009]
+    references:
+      - https://github.com/LloydLabs/wsb-detect
+    examples:
+      - 773290480d5445f11d3dc1b800728966:0x140001140
+  features:
+    - and:
+      - api: CreateFile
+      - string: \\.\GLOBALROOT\device\vmsmb


### PR DESCRIPTION
Ref: https://github.com/fireeye/capa-rules/issues/162

Will currently fail due to https://github.com/fireeye/capa/issues/353

This rule covers the device check done by `wsb-detect` which is pasted below
```c
#define HV_VMSMB_DEV L"\\\\.\\GLOBALROOT\\device\\vmsmb"
```

```c
BOOL wsb_detect_dev(VOID)
{
    return util_path_exists(HV_VMSMB_DEV, 0);
}

```