### PR TITLE
add resolve-function-by-hash

### DIFF
--- a/nursery/resolve-function-by-hash.yml
+++ b/nursery/resolve-function-by-hash.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: resolve function by hash
+    namespace: linking/runtime-linking
+    author: william.ballenthin@fireeye.com
+    scope: function
+    att&ck:
+      - Execution::Shared Modules [T1129]
+    examples:
+    references:
+      - https://www.fireeye.com/blog/threat-research/2012/11/precalculated-string-hashes-reverse-engineering-shellcode.html
+      - https://pastebin.com/ci5XYW4P
+  features:
+    - or:
+      - number: 0x6a4abc5b = ROR13(kernel32.dll)
+      - number: 0x3cfa685d = ROR13(ntdll.dll)
+      - number: 0xec0e4e8e = ROR13(LoadLibraryA)
+      - number: 0x7c0dfcaa = ROR13(GetProcAddress)
+      - number: 0x91afca54 = ROR13(VirtualAlloc)
+      - number: 0x534c0ab8 = ROR13(NtFlushInstructionCache)
+      - number: 0xff7f061a = ROR13(RtlExitUserThread)
+      - number: 0x60e0ceef = ROR13(ExitThread)


### PR DESCRIPTION
adds most common lib/export hashes for ROR13. in theory would could add rules for each of the algos described in the blog post, though im concerned there would be hundreds of thousands of new rule statements that would slow things down.

https://www.fireeye.com/blog/threat-research/2012/11/precalculated-string-hashes-reverse-engineering-shellcode.html