### PR TITLE
Create check-for-windows-sandbox-via-registry.yml

### DIFF
--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-registry.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-registry.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: check for windows sandbox via registry
+    namespace: anti-analysis/anti-vm/vm-detection
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
+    mbc:
+      - Anti-Behavioral Analysis::Virtual Machine Detection [B0009]
+    references:
+      - https://github.com/LloydLabs/wsb-detect
+    examples:
+      - 773290480d5445f11d3dc1b800728966:0x140001140
+  features:
+    - and:
+      - api: RegOpenKeyEx
+      - api: RegEnumValue
+      - string: /\\Microsoft\\Windows\\CurrentVersion\\RunOnce/
+      - string: /wmic useraccount where \"name='WDAGUtilityAccount'\"/i


### PR DESCRIPTION
Ref: https://github.com/fireeye/capa-rules/issues/162

Will not currently trigger due to https://github.com/fireeye/capa/issues/353

Rule is intended to trigger on the following code which checks the registry for information pertaining to the WDAGUtilityAccount account.
```c
#define SANDBOX_LOGON_CMD L"cmd /C wmic useraccount where \"name='WDAGUtilityAccount'\" set PasswordExpires=FALSE"
```
```c
BOOL wsb_detect_cmd(VOID)
{
    BOOL bFound = FALSE;
    DWORD dwFlags = KEY_READ;

#ifndef _WIN64
    dwFlags &= KEY_WOW64_64KEY;
#endif

    HKEY hKey;
    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce"), 0, dwFlags, &hKey) != ERROR_SUCCESS)
    {
        return bFound;
    }

    WCHAR achKey[MAX_KEY_LENGTH];
    WCHAR achValue[MAX_VALUE_NAME];
    RtlSecureZeroMemory(achKey, sizeof(achKey));
    RtlSecureZeroMemory(achValue, sizeof(achValue));
    
    DWORD cchKey = MAX_KEY_LENGTH;
    DWORD cchValue = MAX_VALUE_NAME;
    
    // we don't know the exact key, so just get the value at pos 0
    if (RegEnumValue(hKey, 0, achKey, &cchKey, NULL, NULL, (LPBYTE)achValue, &cchValue) == ERROR_SUCCESS)
    {
        if (wcscmp(achValue, SANDBOX_LOGON_CMD) == 0)
        {
            bFound = TRUE;
        }
    }

    RegCloseKey(hKey);
    return bFound;
}
```
