### PR TITLE
Create check-for-windows-sandbox-via-process-name.yml

### DIFF
--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-process-name.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-process-name.yml
@@ -1,0 +1,18 @@
+rule:
+  meta:
+    name: check for windows sandbox via process name
+    namespace: anti-analysis/anti-vm/vm-detection
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
+    mbc:
+      - Anti-Behavioral Analysis::Virtual Machine Detection [B0009]
+    references:
+      - https://github.com/LloydLabs/wsb-detect
+    examples:
+      - 773290480d5445f11d3dc1b800728966:0x140001140
+  features:
+    - and:
+      - match: enumerate processes
+      - string: CExecSvc.exe


### PR DESCRIPTION
Ref: https://github.com/fireeye/capa-rules/issues/162

Will not trigger due to https://github.com/fireeye/capa/issues/353

This rule will trigger on the following logic from wsb-detect:
```c
#define HV_CONTAINER_NAME L"CExecSvc.exe"
```
```c
BOOL wsb_detect_proc(VOID)
{
    BOOL bFound = FALSE;

    HANDLE hProcesses = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
    if (hProcesses == INVALID_HANDLE_VALUE)
    {
        return FALSE;
    }

    PROCESSENTRY32 pe32Entry;
    pe32Entry.dwSize = sizeof(PROCESSENTRY32);

    if (!Process32First(hProcesses, &pe32Entry))
    {
        CloseHandle(hProcesses);
        return FALSE;
    }

    do
    {
        if (wcscmp(pe32Entry.szExeFile, HV_CONTAINER_NAME))
        {
            bFound = TRUE;
            break;
        }
    } 
    while (Process32Next(hProcesses, &pe32Entry));

    CloseHandle(hProcesses);
    return bFound;
}
```