### PR TITLE
Create check-for-windows-sandbox-via-mutex.yml

### DIFF
--- a/nursery/check-for-windows-sandbox-via-mutex.yml
+++ b/nursery/check-for-windows-sandbox-via-mutex.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: check for windows sandbox via mutex
+    namespace: anti-analysis/anti-vm/vm-detection
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
+    mbc:
+      - Anti-Behavioral Analysis::Virtual Machine Detection [B0009]
+    references:
+      - https://github.com/LloydLabs/wsb-detect
+  features:
+    - and:
+      - match: check mutex
+      - string: WindowsSandboxMutex


### PR DESCRIPTION
Ref: https://github.com/fireeye/capa-rules/issues/162

In the Trivia section of the Readme, but not in the build of the utility.

> Also, it's possible on the host to detect if the sandbox is running, by checking if you can create a mutex named `WindowsSandboxMutex`. This limits the sandbox to one virtual-machine per host, however, you can release this mutex by simply duplicating the handle and calling `ReleaseMutex` - viola, you can have multiple instances.

![mutex check in latest build at 0x140021F1C](https://i.imgur.com/XWupOpm.png)