### PR TITLE
Create check-for-windows-sandbox-via-dns-suffix.yml

### DIFF
--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-dns-suffix.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-dns-suffix.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: check for windows sandbox via dns suffix
+    namespace: anti-analysis/anti-vm/vm-detection
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
+    mbc:
+      - Anti-Behavioral Analysis::Virtual Machine Detection [B0009]
+    references:
+      - https://github.com/LloydLabs/wsb-detect
+    examples:
+      - 773290480d5445f11d3dc1b800728966:0x140001140
+  features:
+    - and:
+      - api: GetAdaptersAddresses
+      - string: mshome.net
+      - offset: 0x38 = DnsSuffix
+      - match: contain loop


### PR DESCRIPTION
Wrapping up work on https://github.com/fireeye/capa-rules/issues/162

Will not trigger due to https://github.com/fireeye/capa/issues/353

This rule will trigger on the following function in `wsb-detect `

```c
#define SANDBOX_DNS_SUFFIX L"mshome.net"
```
```c
BOOL wsb_detect_suffix(VOID)
{
    BOOL bFound = FALSE;

    DWORD dwAdapterFlags = 0;
    DWORD dwAddrSize = 0;
    if (GetAdaptersAddresses(AF_INET, dwAdapterFlags, NULL, NULL, &dwAddrSize) == 0)
    {
        return FALSE;
    }

    PIP_ADAPTER_ADDRESSES pAdapterAddrs;
    PIP_ADAPTER_ADDRESSES pAdapt;
    if ((pAdapterAddrs = (PIP_ADAPTER_ADDRESSES)GlobalAlloc(GPTR, dwAddrSize)) == NULL)
    {
        return FALSE;
    }

    if (GetAdaptersAddresses(AF_INET, dwAdapterFlags, NULL, pAdapterAddrs, &dwAddrSize) != ERROR_SUCCESS)
    {
        GlobalFree(pAdapterAddrs);
        return FALSE;
    }

    for (pAdapt = pAdapterAddrs; pAdapt; pAdapt = pAdapt->Next)
    {
        if (wcscmp(pAdapt->DnsSuffix, SANDBOX_DNS_SUFFIX) == 0)
        {
            bFound = TRUE;
            break;
        }
    }

    GlobalFree(pAdapterAddrs);
    return bFound;
}

```