### PR TITLE
Create capture-public-ip.yml

### DIFF
--- a/collection/network/capture-public-ip.yml
+++ b/collection/network/capture-public-ip.yml
@@ -1,0 +1,25 @@
+rule:
+  meta:
+    name: capture public ip
+    namespace: collection/network
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Discovery::System Network Configuration Discovery [T1016]
+    examples:
+      - 84f1b049fa8962b215a77f51af6714b3:0x100061e5
+  features:
+    - and:
+      - api: InternetOpen
+      - api: InternetOpenUrl
+      - api: InternetReadFile
+      - or:
+          - string: /bot\.whatismyipaddress.com/
+          - string: /ipinfo.io\/ip/
+          - string: /checkip\.dyndns\.org/
+          - string: /ifconfig\.me/
+          - string: /ipecho\.net\/plain/
+          - string: /api\.ipify\.org/
+          - string: /checkip\.amazonaws\.com/
+          - string: /icanhazip\.com/
+          - string: /wtfismyip\.com/text/


### PR DESCRIPTION
I thought there was already a rule like this, but after searching I didn't see one.  

This rule is intended to trigger on the function of some bots when they reach out to external sites to determine the public IP.

An example of this can be seen at https://github.com/quantumcored/paradoxiaRAT
```c
if (strcmp(recvbuf, "wanip") == 0)
        {
            char* wanip[BUFFER];
            HINTERNET hInternet, hFile;
            DWORD rSize;
            if (InternetCheckConnection("http://www.google.com", 1, 0)) {
                memset(wanip, '\0', BUFFER);
                hInternet = InternetOpen(NULL, INTERNET_OPEN_TYPE_PRECONFIG, NULL, NULL, 0);
                hFile = InternetOpenUrl(hInternet, "http://bot.whatismyipaddress.com/", NULL, 0, INTERNET_FLAG_RELOAD, 0);
                InternetReadFile(hFile, &wanip, sizeof(wanip), &rSize);
                wanip[rSize] = '\0';

                InternetCloseHandle(hFile);
                InternetCloseHandle(hInternet);
                sockprintf( "WANIP:%s", wanip);
            }
            else {
                sockprintf( "No Internet Connection detected.");
            }
        }

```

I checked through my corpus and added some additional sites.  