### PR TITLE
Create read-virtual-disk.yml

### DIFF
--- a/host-interaction/file-system/read/read-virtual-disk.yml
+++ b/host-interaction/file-system/read/read-virtual-disk.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: read virtual disk
+    namespace: host-interaction/file-system/read
+    author: "@_re_fox"
+    scope: function
+    references:
+      - https://github.com/vxunderground/VXUG-Papers/blob/main/Weaponizing%20Windows%20Virtualization/src.cpp
+      - https://github.com/vxunderground/VXUG-Papers/blob/main/Weaponizing%20Windows%20Virtualization/WeaponizingWindowsVirtualization.pdf
+    examples:
+      - 3265b2b0afc6d2ad0bdd55af8edb9b37:0x00410637
+  features:
+    - and:
+      - api: OpenVirtualDisk
+      - api: AttachVirtualDisk
+      - api: GetVirtualDiskPhysicalPath
+      - optional:
+        - and:
+          - number: 0xec984aec
+          - number: 0x47e9a0f9
+          - number: 0x41711f90
+          - number: 0x5b34665a


### PR DESCRIPTION
This addresses https://github.com/fireeye/capa-rules/issues/177 which handles reading Virtual Disk files.  

I included the constants that make up the guid (shown below) as optional.  Due to the number of variations that could exist.  
```c
    static GUID VIRTUAL_STORAGE_TYPE_VENDOR_MICROSOFT_EX = { 0xEC984AEC ,0xA0F9, 0x47e9, 0x901F, 0x71415A66345B };
```
