### PR TITLE
Graduate rule nursery/access-the-windows-event-log.yml

### DIFF
--- a/host-interaction/log/winevt/access/access-the-windows-event-log.yml
+++ b/host-interaction/log/winevt/access/access-the-windows-event-log.yml
@@ -4,6 +4,8 @@ rule:
     namespace: host-interaction/log/winevt/access
     author: moritz.raabe@fireeye.com
     scope: function
+    examples:
+      - mimikatz.exe_:0x45228B
   features:
     - or:
       - api: OpenEventLog


### PR DESCRIPTION
:mortar_board: 

Graduating nursery rule into namespace folder, and updated with example.