### PR TITLE
Create capture-microphone-audio.yml

### DIFF
--- a/collection/microphone/capture-microphone-audio.yml
+++ b/collection/microphone/capture-microphone-audio.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: capture microphone audio
+    namespace: collection/microphone
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Collection::Audio Capture [T1123]
+    examples:
+      - a70052c45e907820187c7e6bcdc7ecca:0x405B40
+  features:
+    - and:
+      - api: mciSendString
+      - string: /^open/i
+      - string: /waveaudio/i
+      - string: /^record/i


### PR DESCRIPTION
Sample file added in https://github.com/fireeye/capa-testfiles/pull/42

Addresses https://github.com/fireeye/capa-rules/issues/176

This is a rule targeting functions that use `mciSendString` for purposes of capturing microphone data.  Most implementations I've observed have been fairly simple self-contained functions.   The only thing of note is that I anchored the 2 strings `open` and `record` to reduce FPs.

The Ghidra decompiled output from this function shows another variant that is roughly similar to the versions posted in the original issue.

```c
void __cdecl FUN_00405b40(char *param_1,DWORD param_2)

{
  strlen(param_1);
  FUN_00421f40();
  mciSendStringA("open new type waveaudio alias mic buffer 6",(LPSTR)0x0,0,(HWND)0x0);
  mciSendStringA("record mic",(LPSTR)0x0,0,(HWND)0x0);
  Sleep(param_2);
  mciSendStringA("stop mic",(LPSTR)0x0,0,(HWND)0x0);
  sprintf(&stack0xfffffff0,"save mic %s",param_1);
  mciSendStringA(&stack0xfffffff0,(LPSTR)0x0,0,(HWND)0x0);
  mciSendStringA("close mic",(LPSTR)0x0,0,(HWND)0x0);
  return;
}
```