### PR TITLE
Graduate inject-apc.yml

### DIFF
--- a/host-interaction/process/inject/inject-apc.yml
+++ b/host-interaction/process/inject/inject-apc.yml
@@ -6,6 +6,8 @@ rule:
     scope: function
     att&ck:
       - Defense Evasion::Process Injection::Asynchronous Procedure Call [T1055.004]
+    examples:
+      - al-khaser_x64.exe_:0x140019348
   features:
     - and:
       - or:
@@ -19,5 +21,6 @@ rule:
         - api: ntdll.NtQueueApcThread
       - optional:
         - or:
+          - number: 0x1fffff = THREAD_ALL_ACCESS
           - api: kernel32.CreateProcess
           - api: kernel32.OpenProcess


### PR DESCRIPTION
:mortar_board: 

Another rule graduation, I added in an additional optional constant for `THREAD_ALL_ACCESS` 

As observed in https://github.com/LordNoteworthy/al-khaser/blob/136de8393de69dd9cab8103316e6da32681200df/al-khaser/CodeInjection/QueueUserAPC.cpp#L135
