### PR TITLE
Create hash-data-using-fnv-1.yml

### DIFF
--- a/data-manipulation/hashing/fnv/hash-data-using-fnv-1.yml
+++ b/data-manipulation/hashing/fnv/hash-data-using-fnv-1.yml
@@ -9,14 +9,17 @@ rule:
     examples:
       - ad4229879180e267f431ac6666b6a0a2:0x14007B4D4
   features:
-    - or:
-      - and:
-        - characteristic: loop
+    - and:
+      - characteristic: loop
+      - or:
         - number/x64: 0xcbf29ce484222325 = FNV_offset_basis
-        - basic block:
-          - and:
+        - number/x32: 0x811c9dc5 = FNV_offset_basis
+      - basic block:
+        - and:
+          - characteristic: nzxor
+          - or:
             - number/x64: 0x100000001b3 = FNV prime
-            - characteristic: nzxor
-            - or:
-              - mnemonic: imul
-              - mnemonic: mul
+            - number/x32: 0x01000193 = FNV prime
+          - or:
+            - mnemonic: imul
+            - mnemonic: mul

--- a/data-manipulation/hashing/fnv/hash-data-using-fnv-1.yml
+++ b/data-manipulation/hashing/fnv/hash-data-using-fnv-1.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: hash data using fnv-1
+    namespace: data-manipulation/hashing/fnv
+    author: "@_re_fox"
+    scope: function
+    references:
+      - https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+    examples:
+      - ad4229879180e267f431ac6666b6a0a2:0x14007B4D4
+  features:
+    - or:
+      - and:
+        - characteristic: loop
+        - number/x64: 0xcbf29ce484222325 = FNV_offset_basis
+        - basic block:
+          - and:
+            - number/x64: 0x100000001b3 = FNV prime
+            - characteristic: nzxor
+            - or:
+              - mnemonic: imul
+              - mnemonic: mul


### PR DESCRIPTION
Hashing using FNV-1.

This rule is not as robust as murmur, but the constants are fairly specific.  

Testing against `capa-testfiles` did not yield any false positives.