### PR TITLE
Create compiled-with-perl2exe.yml

### DIFF
--- a/compiler/perl2exe/compiled-with-perl2exe.yml
+++ b/compiler/perl2exe/compiled-with-perl2exe.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: compiled with perl2exe
+    namespace: compiler/perl2exe
+    author: "@_re_fox"
+    scope: function
+    examples:
+      - 873275ce8bf88ef66e9fa0c74b5c2a1e:0x4011C9
+  features:
+    - and:
+      - api: LoadLibrary
+      - api: FreeLibrary
+      - string: /^p2x[a-z0-9]{1,10}\.dll/i 
+      - basic block:
+        - and:
+          - api: GetProcAddress
+          - string: RunPerl


### PR DESCRIPTION
Sample uploaded in https://github.com/fireeye/capa-testfiles/pull/54

This rule looks for a sample that is compiled with perl2exe, focusing on the function that loads up the `P2XDLL` and loading the `RunPerl` function.