### PR TITLE
Create compiled-with-ps2exe.yml

### DIFF
--- a/compiler/ps2exe/compiled-with-ps2exe.yml
+++ b/compiler/ps2exe/compiled-with-ps2exe.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: compiled with ps2exe
+    namespace: compiler/ps2exe
+    author: "@_re_fox"
+    scope: file
+    references:
+      - https://github.com/ikarstein/ps2exe
+    examples:
+      - 8775ed26068788279726e08ff9665aab
+  features:
+    - and:
+      - match: compiled to the .NET platform
+      - string: PS2EXEApp
+      - string: PS2EXE
+      - string: PS2EXE_Host


### PR DESCRIPTION
This rule will trigger on applications bundled via PS2EXE.  The strings that are in the rule are taken directly from https://github.com/ikarstein/ps2exe/blob/master/ps2exe.ps1 and compared against the file in PR https://github.com/fireeye/capa-testfiles/pull/55