### PR TITLE
Create compiled-with-pyarmor.yml

### DIFF
--- a/compiler/pyarmor/compiled-with-pyarmor.yml
+++ b/compiler/pyarmor/compiled-with-pyarmor.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: compiled with dashingsoft pyarmor
+    name: compiled with pyarmor
     namespace: compiler/pyarmor
     author: "@stvemillertime, @itreallynick"
     scope: file

--- a/compiler/pyarmor/compiled-with-pyarmor.yml
+++ b/compiler/pyarmor/compiled-with-pyarmor.yml
@@ -9,8 +9,7 @@ rule:
     references:
       - https://twitter.com/stvemillertime/status/1349032548580483073
     examples:
-      - 0e054493c82baf64b30f3cb0349843dedd8f8e25e8f53eec0a9d7ed2dbadb20a.exe_
-      - 000286df4376dc71b1f5d8367b2da929bc016c441651365268077a08548d0e67.exe_
+      - a0fb20bc9aa944c3a0a6c4545c195818
   features:
     - or:
       - string: pyarmor_runtimesh

--- a/compiler/pyarmor/compiled-with-pyarmor.yml
+++ b/compiler/pyarmor/compiled-with-pyarmor.yml
@@ -8,6 +8,9 @@ rule:
       - Execution::Command and Scripting Interpreter::Python [T1059.006]
     references:
       - https://twitter.com/stvemillertime/status/1349032548580483073
+    examples:
+      - 0e054493c82baf64b30f3cb0349843dedd8f8e25e8f53eec0a9d7ed2dbadb20a.exe_
+      - 000286df4376dc71b1f5d8367b2da929bc016c441651365268077a08548d0e67.exe_
   features:
     - or:
       - string: pyarmor_runtimesh

--- a/compiler/pyarmor/compiled-with-pyarmor.yml
+++ b/compiler/pyarmor/compiled-with-pyarmor.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: compiled with dashingsoft pyarmor
+    namespace: compiler/pyarmor
+    author: "@stvemillertime, @itreallynick"
+    scope: file
+    att&ck:
+      - Execution::Command and Scripting Interpreter::Python [T1059.006]
+    references:
+      - https://twitter.com/stvemillertime/status/1349032548580483073
+  features:
+    - or:
+      - string: pyarmor_runtimesh
+      - string: PYARMOR
+      - string: __pyarmor__
+      - string: PYARMOR_SIGNATURE


### PR DESCRIPTION
Coverage for Dashingsoft's pyarmor, as referenced in [recent public communications](https://twitter.com/stvemillertime/status/1349032548580483073) from the Honorable Doctor Steven Miller of the FireEye Institute (@stvemillertime).
This is a basic rule to help people understand what may have obfuscated the file they are analyzing.
Fellow scientists may debate whether or not this is truly a compiler or an obfuscator belonging elsewhere in the namespace tree, but to them I say: 'ok sure I barely even know if I'm doing this right so, fine'
It may also be worth looking at https://github.com/liftoff/pyminifier 👀  and then just making a wider collection of PE obfuscator/compilers from scripting languages. I am using GitHub in dark mode if it helps.

![image](https://user-images.githubusercontent.com/7584935/104349034-6a670800-54d0-11eb-9ada-6c961af2cd5d.png)
Ok don't mind if I do...
https://user-images.githubusercontent.com/7584935/104348958-4f949380-54d0-11eb-8625-5b2bfed6993c.mov