### PR TITLE
update mappings for mbc (part 5)

### DIFF
--- a/anti-analysis/anti-disasm/64-bit-execution-via-heavens-gate.yml
+++ b/anti-analysis/anti-disasm/64-bit-execution-via-heavens-gate.yml
@@ -5,6 +5,8 @@ rule:
     author: '@recvfrom'
     description: Looks for instructions related to executing 64-bit code from a 32-bit process (Heaven's Gate)
     scope: function
+    mbc:
+      - Defense Evasion::Disable or Evade Security Tools::Heavens Gate [F0004.008]
     examples:
       - 79abd17391adc6251ecdc58d13d76baf:0x10002385
     references:

--- a/anti-analysis/anti-disasm/contain-anti-disasm-techniques.yml
+++ b/anti-analysis/anti-disasm/contain-anti-disasm-techniques.yml
@@ -4,6 +4,8 @@ rule:
     namespace: anti-analysis/anti-disasm
     author: moritz.raabe@fireeye.com
     scope: file
+    mbc:
+      - Anti-Static Analysis::Disassembler Evasion [B0012]
     examples:
       - a5c70086b3bc4fe64f4e7a0aa452e620
   features:

--- a/collection/credit-card/parse-credit-card-information.yml
+++ b/collection/credit-card/parse-credit-card-information.yml
@@ -4,6 +4,8 @@ rule:
     namespace: collection/credit-card
     author: "@_re_fox"
     scope: function
+    mbc:
+      - Data::Check String [C0019]
     examples:
       - 1d8fd13c890060464019c0f07b928b1a:0x402860
   features:

--- a/data-manipulation/checksum/adler32/compute-adler32-checksum.yml
+++ b/data-manipulation/checksum/adler32/compute-adler32-checksum.yml
@@ -4,6 +4,8 @@ rule:
     namespace: data-manipulation/checksum/adler32
     author: matthew.williams@fireeye.com
     scope: function
+    mbc:
+      - Data::Checksum::Adler [C0032.005]
     references:
       - https://en.wikipedia.org/wiki/Adler-32
     examples:

--- a/data-manipulation/hashing/fnv/hash-data-using-fnv.yml
+++ b/data-manipulation/hashing/fnv/hash-data-using-fnv.yml
@@ -7,6 +7,8 @@ rule:
       - "@_re_fox"
     description: can be any Fowler-Noll-Vo (FNV) hash variant, including FNV-1, FNV-1a, FNV-0
     scope: function
+    mbc:
+      - Data::Non-Cryptographic Hash::FNV [C0030.005]
     references:
       - https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
       - http://isthe.com/chongo/tech/comp/fnv/

--- a/executable/subfile/pe/contain-an-embedded-pe-file.yml
+++ b/executable/subfile/pe/contain-an-embedded-pe-file.yml
@@ -4,6 +4,8 @@ rule:
     namespace: executable/subfile/pe
     author: moritz.raabe@fireeye.com
     scope: file
+    mbc:
+      - Execution::Install Additional Program [B0023]
     examples:
       - Practical Malware Analysis Lab 01-04.exe_:0x4060
   features:

--- a/host-interaction/file-system/read/read-virtual-disk.yml
+++ b/host-interaction/file-system/read/read-virtual-disk.yml
@@ -4,6 +4,8 @@ rule:
     namespace: host-interaction/file-system/read
     author: "@_re_fox"
     scope: function
+    mbc:
+      - File System::Read Virtual Disk [C0056]
     references:
       - https://github.com/vxunderground/VXUG-Papers/blob/main/Weaponizing%20Windows%20Virtualization/src.cpp
       - https://github.com/vxunderground/VXUG-Papers/blob/main/Weaponizing%20Windows%20Virtualization/WeaponizingWindowsVirtualization.pdf

--- a/host-interaction/file-system/windows-file-protection/bypass-windows-file-protection.yml
+++ b/host-interaction/file-system/windows-file-protection/bypass-windows-file-protection.yml
@@ -5,7 +5,7 @@ rule:
     author: michael.hunhoff@fireeye.com
     scope: function
     mbc:
-      - Defense Evasion::Disable Security Tools::Bypass Windows File Protection [F0004.007]
+      - Defense Evasion::Disable or Evade Security Tools::Bypass Windows File Protection [F0004.007]
     examples:
       - Practical Malware Analysis Lab 01-04.exe_:0x401174
   features:

--- a/host-interaction/hardware/keyboard/simulate-ctrl-alt-del.yml
+++ b/host-interaction/hardware/keyboard/simulate-ctrl-alt-del.yml
@@ -4,6 +4,8 @@ rule:
     namespace: host-interaction/hardware/keyboard
     author: michael.hunhoff@fireeye.com
     scope: function
+    mbc:
+      - Hardware::Simulate Hardware::Ctrl-Alt-Del [C0057.001]
     examples:
       - 50D5EE1CE2CA5E30C6B1019EE64EEEC2:0x407C27
   features:

--- a/host-interaction/registry/delete/delete-registry-value.yml
+++ b/host-interaction/registry/delete/delete-registry-value.yml
@@ -4,6 +4,8 @@ rule:
     namespace: host-interaction/registry/delete
     author: michael.hunhoff@fireeye.com
     scope: function
+    mbc:
+      - Operating System::Registry::Delete Registry Value [C0036.007]
     examples:
       - B5F85C26D7AA5A1FB4AF5821B6B5AB9B:0x4041A0
   features:

--- a/lib/calculate-modulo-256-via-x86-assembly.yml
+++ b/lib/calculate-modulo-256-via-x86-assembly.yml
@@ -4,6 +4,8 @@ rule:
     author: moritz.raabe@fireeye.com
     lib: true
     scope: basic block
+    mbc:
+      - Data::Modulo [C0058]
     examples:
       - 9324D1A8AE37A36AE560C37448C9705A:0x4049A9
   features:

--- a/lib/create-or-open-file.yml
+++ b/lib/create-or-open-file.yml
@@ -4,6 +4,8 @@ rule:
     author: michael.hunhoff@fireeye.com
     lib: true
     scope: basic block
+    mbc:
+      - File System::Create File [C0016]
     examples:
       - B5F85C26D7AA5A1FB4AF5821B6B5AB9B:0x401D7E
   features:

--- a/lib/delay-execution.yml
+++ b/lib/delay-execution.yml
@@ -4,6 +4,8 @@ rule:
     author: michael.hunhoff@fireeye.com
     lib: true
     scope: basic block
+    mbc:
+      - Anti-Behavioral Analysis::Dynamic Analysis Evasion::Delayed Execution [B0003.003]
     references:
       - https://docs.microsoft.com/en-us/windows/win32/sync/wait-functions
       - https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser/TimingAttacks/timing.cpp

--- a/lib/peb-access.yml
+++ b/lib/peb-access.yml
@@ -4,6 +4,8 @@ rule:
     author: michael.hunhoff@fireeye.com
     lib: true
     scope: basic block
+    mbc:
+      - Anti-Behavioral Analysis::Debugger Detection::Process Environment Block [B0001.019]
     references:
       - https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser/AntiDebug/NtGlobalFlag.cpp
     examples:

--- a/lib/validate-payment-card-number-using-luhn-algorithm-with-lookup-table.yml
+++ b/lib/validate-payment-card-number-using-luhn-algorithm-with-lookup-table.yml
@@ -4,6 +4,8 @@ rule:
     lib: true
     author: "@_re_fox"
     scope: function
+    mbc:
+      - Data::Checksum::Luhn [C0032.002]
     examples:
       - 1d8fd13c890060464019c0f07b928b1a:0x401920
       - 60abaef3fda131ffa20df480cb3f8029:0x4048e0

--- a/lib/validate-payment-card-number-using-luhn-algorithm-with-no-lookup-table.yml
+++ b/lib/validate-payment-card-number-using-luhn-algorithm-with-no-lookup-table.yml
@@ -4,6 +4,8 @@ rule:
     lib: true
     author: "@_re_fox"
     scope: function
+    mbc:
+      - Data::Checksum::Luhn [C0032.002]
     examples:
       - 6fcc13563aad936c7d0f3165351cb453:0x4026C0
   features:

--- a/linking/static/cryptopp/linked-against-crypto.yml
+++ b/linking/static/cryptopp/linked-against-crypto.yml
@@ -4,6 +4,8 @@ rule:
     namespace: linking/static/cryptopp
     author: moritz.raabe@fireeye.com
     scope: file
+    mbc:
+      - Cryptography::Crypto Library [C0059]
     examples:
       - 8BA66E4B618FFDC8255F1DF01F875DDE6FD0561305D9F8307BE7BB11D02AE363
       - 66602B5FAB602CB4E6F754748D249542

--- a/linking/static/openssl/linked-against-openssl.yml
+++ b/linking/static/openssl/linked-against-openssl.yml
@@ -4,6 +4,8 @@ rule:
     namespace: linking/static/openssl
     author: william.ballenthin@fireeye.com
     scope: file
+    mbc:
+      - Cryptography::Crypto Library [C0059]
     examples:
       - 6cc148363200798a12091b97a17181a1
   features:

--- a/linking/static/polarssl/linked-against-polarsslmbed-tls.yml
+++ b/linking/static/polarssl/linked-against-polarsslmbed-tls.yml
@@ -4,6 +4,8 @@ rule:
     namespace: linking/static/polarssl
     author: william.ballenthin@fireeye.com
     scope: file
+    mbc:
+      - Cryptography::Crypto Library [C0059]
     examples:
       - 232b0a8546035d9017fadf68398826edb0a1e055566bc1d356d6c9fdf1d7e485
   features:

--- a/linking/static/zlib/linked-against-zlib.yml
+++ b/linking/static/zlib/linked-against-zlib.yml
@@ -4,6 +4,8 @@ rule:
     namespace: linking/static/zlib
     author: william.ballenthin@fireeye.com
     scope: file
+    mbc:
+      - Data::Compression Library [C0060]
     examples:
       - 6cc148363200798a12091b97a17181a1
   features:


### PR DESCRIPTION
Added MBC mappings to lib and linking namespaces, as well as for rules in other namespaces that were added after those namespaces were originally mapped to MBC. Where possible, all but nursery namespace have been mapped.