### PR TITLE
adding inspect-load-icon-resource.yml

### DIFF
--- a/nursery/inspect-load-icon-resource.yml
+++ b/nursery/inspect-load-icon-resource.yml
@@ -1,0 +1,26 @@
+# generated using capa explorer for IDA Pro
+rule:
+  meta:
+    name: inspect load icon resource
+    namespace: anti-analysis
+    author: michael.hunhoff@fireeye.com
+    scope: basic block
+  features:
+    # check if call to LoadIcon fails when first argument is NULL
+    # and second argument is not a valid predefined icon - LoadIcon
+    # should return NULL here, but some sandboxes/emulation may instead
+    # return a valid handle
+    - and:
+      - api: user32.LoadIcon
+      - number: 0x0
+      - mnemonic: test
+      - not:
+        - or:
+          - description: predefined icon identifiers
+          - number: 0x7F05 = IDI_WINLOGO
+          - number: 0x7F06 = IDI_SHIELD
+          - number: 0x7F02 = IDI_QUESTION
+          - number: 0x7F00 = IDI_APPLICATION
+          - number: 0x7F04 = (IDI_ASTERISK | IDI_INFORMATION)
+          - number: 0x7F01 = (IDI_ERROR | IDI_HAND)
+          - number: 0x7F03 = (IDI_EXCLAMATION | IDI_WARNING)


### PR DESCRIPTION
interesting anti-analysis technique most likely meant to evade sandbox/emulation.

from MS docs for `LoadIcon`: _To use one of the predefined icons, set the hInstance parameter to NULL and the lpIconName parameter to one of the following values.....If the function fails, the return value is NULL._

observed numerous calls to `LoadIcon` passing `NULL` for first argument and random identifier for second argument, with a check for `NULL` return following each call.