### PR TITLE
removing ntdll requirement from function features exported by both ntdll and ntoskrnl

### DIFF
--- a/executable/resource/extract-resource-via-kernel32-functions.yml
+++ b/executable/resource/extract-resource-via-kernel32-functions.yml
@@ -15,7 +15,7 @@ rule:
         - or:
           - api: kernel32.LoadResource
           - api: kernel32.LockResource
-          - api: ntdll.LdrAccessResource
+          - api: LdrAccessResource
         - optional:
           - match: contain a resource (.rsrc) section
           - api: kernel32.GetModuleHandle
@@ -23,8 +23,8 @@ rule:
           - or:
             - api: kernel32.FindResource
             - api: kernel32.FindResourceEx
-            - api: ntdll.LdrFindResource_U
-            - api: ntdll.LdrFindResourceEx_U
+            - api: LdrFindResource_U
+            - api: LdrFindResourceEx_U
           - api: kernel32.SizeofResource
           - api: kernel32.FreeResource
       - api: user32.LoadString

--- a/host-interaction/file-system/files/list/enumerate-files-via-ntdll-functions.yml
+++ b/host-interaction/file-system/files/list/enumerate-files-via-ntdll-functions.yml
@@ -18,6 +18,6 @@ rule:
           - api: ntdll.NtOpenDirectoryObject
       - api: ntdll.NtQueryDirectoryObject
       - optional:
-        - api: ntdll.RtlAllocateHeap
+        - api: RtlAllocateHeap
         - match: contain loop
         - characteristic: indirect call

--- a/host-interaction/file-system/write/write-file.yml
+++ b/host-interaction/file-system/write/write-file.yml
@@ -21,12 +21,12 @@ rule:
           - and:
             - number: 0x2 = FILE_WRITE_DATA
             - or:
-              - api: ntdll.NtCreateFile
+              - api: NtCreateFile
               - api: ZwCreateFile
       - or:
         - api: kernel32.WriteFile
         - api: kernel32.WriteFileEx
-        - api: ntdll.NtWriteFile
+        - api: NtWriteFile
         - api: ZwWriteFile
         - api: _fwrite
         - api: fwrite

--- a/host-interaction/os/info/get-system-information.yml
+++ b/host-interaction/os/info/get-system-information.yml
@@ -12,8 +12,8 @@ rule:
     - or:
       - api: kernel32.GetSystemInfo
       - api: kernel32.GetNativeSystemInfo
-      - api: ntdll.NtQuerySystemInformation
-      - api: ntdll.NtQuerySystemInformationEx
+      - api: NtQuerySystemInformation
+      - api: NtQuerySystemInformationEx
       - api: ntdll.RtlGetNativeSystemInformation
       - api: ZwQuerySystemInformation
       - api: ZwQuerySystemInformationEx

--- a/host-interaction/process/inject/inject-apc.yml
+++ b/host-interaction/process/inject/inject-apc.yml
@@ -13,7 +13,7 @@ rule:
       - or:
         - match: write process memory
         - api: kernel32.MapViewOfSection
-        - api: ntdll.NtMapViewOfSection
+        - api: NtMapViewOfSection
         - api: ntdll.ZwMapViewOfSection
         - api: kernel32.MapViewOfFile
       - or:

--- a/host-interaction/process/list/enumerate-processes-via-ntquerysysteminformation.yml
+++ b/host-interaction/process/list/enumerate-processes-via-ntquerysysteminformation.yml
@@ -12,4 +12,4 @@ rule:
   features:
     - and:
       - number: 0x5 = SYSTEM_PROCESS_INFORMATION
-      - api: ntdll.NtQuerySystemInformation
+      - api: NtQuerySystemInformation

--- a/lib/allocate-memory.yml
+++ b/lib/allocate-memory.yml
@@ -17,7 +17,7 @@ rule:
       - api: kernel32.VirtualAllocExNuma
       - api: kernel32.VirtualProtect
       - api: kernel32.VirtualProtectEx
-      - api: ntdll.NtAllocateVirtualMemory
-      - api: ntdll.ZwAllocateVirtualMemory
-      - api: ntdll.NtMapViewOfSection
-      - api: ntdll.ZwMapViewOfSection
+      - api: NtAllocateVirtualMemory
+      - api: ZwAllocateVirtualMemory
+      - api: NtMapViewOfSection
+      - api: ZwMapViewOfSection

--- a/lib/open-process.yml
+++ b/lib/open-process.yml
@@ -9,5 +9,5 @@ rule:
   features:
     - or:
       - api: kernel32.OpenProcess
-      - api: ntdll.NtOpenProcess
-      - api: ntdll.ZwOpenProcess
+      - api: NtOpenProcess
+      - api: ZwOpenProcess

--- a/lib/open-thread.yml
+++ b/lib/open-thread.yml
@@ -9,5 +9,5 @@ rule:
   features:
     - or:
       - api: kernel32.OpenThread
-      - api: ntdll.NtOpenThread
-      - api: ntdll.ZwOpenThread
+      - api: NtOpenThread
+      - api: ZwOpenThread

--- a/load-code/pe/access-pe-header.yml
+++ b/load-code/pe/access-pe-header.yml
@@ -10,5 +10,5 @@ rule:
       - 563653399B82CD443F120ECEFF836EA3678D4CF11D9B351BB737573C2D856299:0x1400018E0
   features:
     - or:
-      - api: ntdll.RtlImageNtHeader
+      - api: RtlImageNtHeader
       - api: ntdll.RtlImageNtHeaderEx


### PR DESCRIPTION
removing the `ntdll` requirement from function features that are exported by both `ntdll` and `ntoskrnl` will improve hits for kernel drivers e.g. #240.