### PR TITLE
New capabilities for Go files

### DIFF
--- a/nursery/capture-screenshot-go.yml
+++ b/nursery/capture-screenshot-go.yml
@@ -15,7 +15,8 @@ rule:
       - match: compiled with Go
       - or:
         - and:
-          - string: syscall.NewLazyDLL # Dynamic loading of DLLs
+          - string: syscall.NewLazyDLL
+            description: Dynamic loading of DLLs
           - or:
             - and:
               - string: /user32.dll/
@@ -28,4 +29,3 @@ rule:
                 - string: /BitBlt/
                 - string: /GetDIBits/
           - string: /CreateCompatibleDC/
-

--- a/nursery/capture-screenshot-go.yml
+++ b/nursery/capture-screenshot-go.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: capture screenshot (Go)
+    name: capture screenshot in Go
     namespace: collection/screenshot
     description: Detects screenshot capability via WinAPI for Go files.
     author:

--- a/nursery/capture-screenshot-go.yml
+++ b/nursery/capture-screenshot-go.yml
@@ -1,0 +1,31 @@
+rule:
+  meta:
+    name: capture screenshot (Go)
+    namespace: collection/screenshot
+    description: Detects screenshot capability via WinAPI for Go files.
+    author:
+      - joakim@intezer.com
+    scope: file
+    att&ck:
+      - Collection::Screen Capture [T1113]
+    mbc:
+      - Collection::Screen Capture::WinAPI [E1113.m01]
+  features:
+    - and:
+      - match: compiled with Go
+      - or:
+        - and:
+          - string: syscall.NewLazyDLL # Dynamic loading of DLLs
+          - or:
+            - and:
+              - string: /user32.dll/
+              - or:
+                - string: /GetWindowDC/
+                - string: /GetDC/
+            - and:
+              - string: /gdi32.dll/
+              - or:
+                - string: /BitBlt/
+                - string: /GetDIBits/
+          - string: /CreateCompatibleDC/
+

--- a/nursery/enumerate-processes-go.yml
+++ b/nursery/enumerate-processes-go.yml
@@ -8,6 +8,9 @@ rule:
     scope: file
     references:
       - https://pkg.go.dev/github.com/mitchellh/go-ps
+    att&ck:
+      - Discovery::Process Discovery [T1057]
+      - Discovery::Software Discovery [T1518]
   features:
     - and:
       - match: compiled with Go
@@ -15,4 +18,3 @@ rule:
         - or:
           - string: github.com/mitchellh/go-ps.FindProcess
           - string: github.com/mitchellh/go-ps.Processes
-

--- a/nursery/enumerate-processes-go.yml
+++ b/nursery/enumerate-processes-go.yml
@@ -1,0 +1,18 @@
+rule:
+  meta:
+    name: enumerate processes (Go)
+    namespace: host-interaction/process/list
+    description: Enumerating processes using a Go library
+    author:
+      - joakim@intezer.com
+    scope: file
+    references:
+      - https://pkg.go.dev/github.com/mitchellh/go-ps
+  features:
+    - and:
+      - match: compiled with Go
+      - or:
+        - or:
+          - string: github.com/mitchellh/go-ps.FindProcess
+          - string: github.com/mitchellh/go-ps.Processes
+

--- a/nursery/enumerate-processes-go.yml
+++ b/nursery/enumerate-processes-go.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: enumerate processes (Go)
+    name: linked against Go process enumeration library
     namespace: host-interaction/process/list
     description: Enumerating processes using a Go library
     author:

--- a/nursery/golibrary-for-registry.yml
+++ b/nursery/golibrary-for-registry.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: use go library for registry
+    namespace: host-interaction/registry
+    description: Uses a go library for interacting with the Windows registry.
+    author:
+      - joakim@intezer.com
+    scope: file
+    references:
+      - https://github.com/golang/sys
+  features:
+    - and:
+      - match: compiled with Go
+      - or:
+        - string: golang.org/x/sys/windows/registry
+        - string: github.com/golang/sys/windows/registry
+

--- a/nursery/golibrary-for-registry.yml
+++ b/nursery/golibrary-for-registry.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: use Go library for registry
+    name: linked against Go registry library
     namespace: host-interaction/registry
     description: Uses a Go library for interacting with the Windows registry.
     author:

--- a/nursery/golibrary-for-registry.yml
+++ b/nursery/golibrary-for-registry.yml
@@ -12,5 +12,5 @@ rule:
     - and:
       - match: compiled with Go
       - or:
-        - string: golang.org/x/sys/windows/registry
-        - string: github.com/golang/sys/windows/registry
+        - string: golang.org/x/sys/windows/registry.Key.Close
+        - string: github.com/golang/sys/windows/registry.Key.Close

--- a/nursery/golibrary-for-registry.yml
+++ b/nursery/golibrary-for-registry.yml
@@ -1,8 +1,8 @@
 rule:
   meta:
-    name: use go library for registry
+    name: use Go library for registry
     namespace: host-interaction/registry
-    description: Uses a go library for interacting with the Windows registry.
+    description: Uses a Go library for interacting with the Windows registry.
     author:
       - joakim@intezer.com
     scope: file
@@ -14,4 +14,3 @@ rule:
       - or:
         - string: golang.org/x/sys/windows/registry
         - string: github.com/golang/sys/windows/registry
-

--- a/nursery/golibrary-for-wmi.yml
+++ b/nursery/golibrary-for-wmi.yml
@@ -14,6 +14,6 @@ rule:
     - and:
       - match: compiled with Go
       - or:
-        - and:
+        - or:
           - string: github.com/StackExchange/wmi.CreateQuery
           - string: github.com/StackExchange/wmi.Query

--- a/nursery/golibrary-for-wmi.yml
+++ b/nursery/golibrary-for-wmi.yml
@@ -1,8 +1,8 @@
 rule:
   meta:
-    name: compiled with WMI go library
+    name: compiled with WMI Go library
     namespace: collection/database/wmi
-    description: StaxExchange's WMI library is used to interact with WMI.
+    description: StackExchange's WMI library is used to interact with WMI.
     author:
       - joakim@intezer.com
     scope: file
@@ -17,4 +17,3 @@ rule:
         - and:
           - string: github.com/StackExchange/wmi.CreateQuery
           - string: github.com/StackExchange/wmi.Query
-

--- a/nursery/golibrary-for-wmi.yml
+++ b/nursery/golibrary-for-wmi.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: compiled with WMI go library
+    namespace: collection/database/wmi
+    description: StaxExchange's WMI library is used to interact with WMI.
+    author:
+      - joakim@intezer.com
+    scope: file
+    references:
+      - https://github.com/StackExchange/wmi
+    att&ck:
+      - Collection::Data from Information Repositories [T1213]
+  features:
+    - and:
+      - match: compiled with Go
+      - or:
+        - and:
+          - string: github.com/StackExchange/wmi.CreateQuery
+          - string: github.com/StackExchange/wmi.Query
+

--- a/nursery/golibrary-for-wmi.yml
+++ b/nursery/golibrary-for-wmi.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: compiled with WMI Go library
+    name: linked against Go WMI library
     namespace: collection/database/wmi
     description: StackExchange's WMI library is used to interact with WMI.
     author:

--- a/nursery/includes-static-assets.yml
+++ b/nursery/includes-static-assets.yml
@@ -37,7 +37,6 @@ rule:
         - and:
           - string: '/\/bindata\.go/'
             description: go-bindata
-          - string: '/\.bindataRead/'
           - string: '/\.Asset/'
         - and:
           - string: github.com/lu4p/binclude.Include

--- a/nursery/includes-static-assets.yml
+++ b/nursery/includes-static-assets.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: includes static assets (Go)
+    name: linked against Go static asset library
     namespace: executable/resource
     description: Detects if the Go file includes an static assets.
     author:

--- a/nursery/includes-static-assets.yml
+++ b/nursery/includes-static-assets.yml
@@ -35,7 +35,8 @@ rule:
           - string: github.com/GeertJohan/go.rice.FindBox
           - string: github.com/GeertJohan/go.rice.MustFindBox
         - and:
-          - string: '/\/bindata\.go/' # go-bindata
+          - string: '/\/bindata\.go/'
+            description: go-bindata
           - string: '/\.bindataRead/'
           - string: '/\.Asset/'
         - and:
@@ -44,4 +45,3 @@ rule:
           - string: github.com/omeid/go-resources
         - and:
           - string: github.com/pyros2097/go-embed
-

--- a/nursery/includes-static-assets.yml
+++ b/nursery/includes-static-assets.yml
@@ -1,0 +1,47 @@
+rule:
+  meta:
+    name: includes static assets (Go)
+    namespace: executable/resource
+    description: Detects if the Go file includes an static assets.
+    author:
+      - joakim@intezer.com
+    scope: file
+    references:
+      - https://github.com/rakyll/statik
+      - https://github.com/gobuffalo/packr
+      - https://github.com/gobuffalo/packr
+      - https://github.com/GeertJohan/go.rice
+      - https://github.com/kevinburke/go-bindata
+      - https://github.com/lu4p/binclude
+      - https://github.com/lu4p/binclude
+      - https://github.com/omeid/go-resources
+      - https://github.com/pyros2097/go-embed
+  features:
+    - and:
+      - match: compiled with Go
+      - or:
+        - or:
+          - string: github.com/rakyll/statik/fs.IsDefaultNamespace
+          - string: github.com/rakyll/statik/fs.RegisterWithNamespace
+          - string: github.com/rakyll/statik/fs.NewWithNamespace
+          - string: github.com/rakyll/statik/fs.Register
+        - and:
+          - string: github.com/gobuffalo/packr.NewBox
+        - or:
+          - string: github.com/markbates/pkger.Open
+          - string: github.com/markbates/pkger.Include
+          - string: github.com/markbates/pkger.Parse
+        - or:
+          - string: github.com/GeertJohan/go.rice.FindBox
+          - string: github.com/GeertJohan/go.rice.MustFindBox
+        - and:
+          - string: '/\/bindata\.go/' # go-bindata
+          - string: '/\.bindataRead/'
+          - string: '/\.Asset/'
+        - and:
+          - string: github.com/lu4p/binclude.Include
+        - and:
+          - string: github.com/omeid/go-resources
+        - and:
+          - string: github.com/pyros2097/go-embed
+


### PR DESCRIPTION
Add rules for capabilities in Go files based on used third-party libraries. Since Go files are not dynamically linked, imports can not be used. Instead, the functionality has to be inferred from strings found in the file. All rules requires that the "compiled with Go" rule first has matched. The following capabilities have been added:

WMI functionality:
Detects if the file has been compiled with StackExchange's WMI library.

Screenshot capability:
Looks for lazy loading of specific Windows dlls + the name of functions that needs to be resolved.

Included static assets:
Go have multiple third-party libraries to embeds assets. The rule looks for the presence of the most common used libraries.

Process enumeration:
Process enumeration via a third-party library.

Windows registry interaction:
Detects if the file has been compiled with the `sys/windows/registry` extra package provided by the Go maintainers.