### PR TITLE
Update check-if-process-is-running-under-wine.yml

### DIFF
--- a/anti-analysis/anti-emulation/wine/check-if-process-is-running-under-wine.yml
+++ b/anti-analysis/anti-emulation/wine/check-if-process-is-running-under-wine.yml
@@ -14,6 +14,7 @@ rule:
       - ccbf7cba35bab56563c0fbe4237fdc41:0x40d750
   features:
     - or:
+      - string: /SOFTWARE\\Wine/i
       - and:
         - api: GetModuleHandle
         - api: GetProcAddress
@@ -21,6 +22,3 @@ rule:
         - or:
           - string: kernel32.dll
           - string: ntdll.dll
-      - or:
-        - string: /Wine/i
-        - string: /SOFTWARE\\Wine/i


### PR DESCRIPTION
Addressing https://github.com/fireeye/capa-rules/issues/282

I went back through 3 samples in the `capa-testfiles` repo that check for Wine.   
```
capa-testfiles/al-khaser_x64.exe_ 
capa-testfiles/al-khaser_x86.exe_ 
capa-testfiles/ccbf7cba35bab56563c0fbe4237fdc41.exe_ 
```
It looks like the regex of `/Wine/i` wasn't restrictive enough.  Simple removal. 

Thanks for posting the FP @mr-tz :+1: 