### PR TITLE
Update Luhn's algorithm to catch TinyPOS implementation

### DIFF
--- a/lib/validate-payment-card-number-using-luhn-algorithm-with-no-lookup-table.yml
+++ b/lib/validate-payment-card-number-using-luhn-algorithm-with-no-lookup-table.yml
@@ -10,19 +10,19 @@ rule:
       - 6fcc13563aad936c7d0f3165351cb453:0x4026C0
   features:
     - and:
-      - not:
-        - characteristic: nzxor
       - characteristic: loop
         description: Iterate over CC digits
       - or:
         - basic block:
           - and:
             - or:
-              - and:
-                - mnemonic: add
+              - mnemonic: add
               - and:
                 - mnemonic: shl
                 - number: 0x1
+              - and:
+                - mnemonic: imul
+                - number: 0x2
             - mnemonic: cmp
             - number: 0x9
             - description: Digital Root check number*2 < 0x9
@@ -35,6 +35,9 @@ rule:
           - basic block:
             - or:
               - mnemonic: add
+              - and:
+                - mnemonic: imul
+                - number: 0x2
               - and:
                 - mnemonic: shl
                 - number: 0x1
@@ -52,8 +55,11 @@ rule:
       - basic block:
         - or:
           - and:
-            - mnemonic: idiv
-            - mnemonic: cdq
+            - or:
+              - mnemonic: div
+              - and:
+                - mnemonic: idiv
+                - mnemonic: cdq
             - number: 0xa
             - optional:
               - mnemonic: neg


### PR DESCRIPTION
Updated to trigger on a variant of the Luhn checksum used in a TinyPOS sample of `3679ae3462d5005a1967f278b1c40f39`. 

Rather than using an `add` or `shl` for multiplying by 2, this version explicitly uses a `imul`.  In the final step `mod 10`, the authors use a `div`, rather than an `idiv/cdq` or an optimized `shr/imul` combination. 

I checked against the `capa-testfiles` repo and the rule doesn't introduce any false negatives.  This version of the rule is less restrictive (doesn't have a `not: characteristic: nzxor`) so there may be a slight risk of false positives, but I haven't seen any yet. 