### PR TITLE
hash-data-using-fnv: removing arch requirement from number constants

### DIFF
--- a/data-manipulation/hashing/fnv/hash-data-using-fnv.yml
+++ b/data-manipulation/hashing/fnv/hash-data-using-fnv.yml
@@ -5,6 +5,7 @@ rule:
     author:
       - moritz.raabe@fireeye.com
       - "@_re_fox"
+      - michael.hunhoff@fireeye.com
     description: can be any Fowler-Noll-Vo (FNV) hash variant, including FNV-1, FNV-1a, FNV-0
     scope: function
     mbc:
@@ -20,11 +21,11 @@ rule:
       - optional:
         - characteristic: loop
         # FNV-0 hash does not use these initialization values
-        - number/x64: 0xcbf29ce484222325 = FNV_offset_basis
-        - number/x32: 0x811c9dc5 = FNV_offset_basis
+        - number: 0xcbf29ce484222325 = FNV_offset_basis
+        - number: 0x811c9dc5 = FNV_offset_basis
       - or:
-        - number/x64: 0x100000001b3 = FNV prime
-        - number/x32: 0x01000193 = FNV prime
+        - number: 0x100000001b3 = FNV prime
+        - number: 0x01000193 = FNV prime
       - basic block:
         # FNV-1 hash does multiply then XOR
         # FNV-1a hash does XOR then multiply


### PR DESCRIPTION
observed `64-bit` sample referencing `32-bit` number constants:

```asm
mov     ecx, 811C9DC5h
lea     rdx, [rax+rbx]
jmp     short loc_2002EED9
movzx   eax, byte ptr [rbx]
imul    ecx, 1000193h
xor     ecx, eax
add     rbx, 1
```

removing arch requirement from number constants to up the matches.