### PR TITLE
Adding an initial rule for detecting Curve25519 algorithms

### DIFF
--- a/nursery/encrypt-data-using-curve25519.yml
+++ b/nursery/encrypt-data-using-curve25519.yml
@@ -7,7 +7,8 @@ rule:
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     examples:
-      - 0a0882b8da225406cc838991b5f67d11:0x4135f6, 0x416f51
+      - 0a0882b8da225406cc838991b5f67d11:0x4135f6
+      - 0a0882b8da225406cc838991b5f67d11:0x416f51
       - 80372de850597bd9e7e021a94f13f0a1:0x406480, 0x4086f4
   features:
     # initializes a 32-byte array with 

--- a/nursery/encrypt-data-using-curve25519.yml
+++ b/nursery/encrypt-data-using-curve25519.yml
@@ -3,7 +3,7 @@ rule:
     name: encrypt data using Curve25519
     namespace: data-manipulation/encryption/curve25519
     author: dimiter.andonov@fireeye.com
-    scope: function
+    scope: basic block
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     examples:

--- a/nursery/encrypt-data-using-curve25519.yml
+++ b/nursery/encrypt-data-using-curve25519.yml
@@ -1,0 +1,25 @@
+rule:
+  meta:
+    name: encrypt data using Curve25519
+    namespace: data-manipulation/encryption/curve25519
+    author: dimiter.andonov@fireeye.com
+    scope: function
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information [T1027]
+    examples:
+      - 0a0882b8da225406cc838991b5f67d11:0x4135f6, 0x416f51
+      - 80372de850597bd9e7e021a94f13f0a1:0x406480, 0x4086f4
+  features:
+    # initializes a 32-byte array with 
+    #   array[0] = 0xf8, 
+    #   array[31] = array[31] & 0x3f | 0x40
+    - and:
+      - and:
+        - number: 0xf8
+        - mnemonic: and
+      - and:
+        - number: 0x3f
+        - mnemonic: and
+      - and:
+        - number: 0x40
+        - mnemonic: or 

--- a/nursery/encrypt-data-using-curve25519.yml
+++ b/nursery/encrypt-data-using-curve25519.yml
@@ -9,7 +9,8 @@ rule:
     examples:
       - 0a0882b8da225406cc838991b5f67d11:0x4135f6
       - 0a0882b8da225406cc838991b5f67d11:0x416f51
-      - 80372de850597bd9e7e021a94f13f0a1:0x406480, 0x4086f4
+      - 80372de850597bd9e7e021a94f13f0a1:0x406480
+      - 80372de850597bd9e7e021a94f13f0a1:0x4086f4
   features:
     # initializes a 32-byte array with 
     #   array[0] = 0xf8, 


### PR DESCRIPTION
Tested the rule against a couple of known samples that implement Curve25519 encryption. Unfortunately this kind of encryption is not based on well-known constants apart from the setting of the initial buffer.
So, in a nutshell - we'd need to detect a buffer being initialized as follows:

buf[0x00] = 0xf8
buf[0x20] = buf[0x20] & 0x3f | 0x40

This looks unique enough to not produce false positives but I'll strengthen it further if it does.
Let me know if you have any questions and/or feedback. It's my first rule so I'm eager to learn how to do this properly. :)