### PR TITLE
ci: run tests with Python3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,10 @@ jobs:
       with:
         repository: fireeye/capa-testfiles
         path: tests/data
-    - name: Set up Python 2.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 2.7
+        python-version: 3.9
     - name: Install capa
       run: pip install -e .
     # Regular lint is fast, so do this first


### PR DESCRIPTION
Capa master doesn't support Python 2 anymore. Update the `test.yml` workflow to use Python 3 to run the rule linter.