### PR TITLE
Stealer rules targeting file-manager software

### DIFF
--- a/collection/file-managers/gather-3d-ftp-information.yml
+++ b/collection/file-managers/gather-3d-ftp-information.yml
@@ -1,0 +1,18 @@
+rule:
+  meta:
+    name: gather 3d-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.3dftp.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40CA59
+  features:
+    - and:
+      - string: "3D-FTP"
+      - string: "sites.ini"
+      - optional:
+        - string: /\\SiteDesigner/

--- a/collection/file-managers/gather-alftp-information.yml
+++ b/collection/file-managers/gather-alftp-information.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: gather alftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.altools.co.kr/Main/Default.aspx
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40A257
+  features:
+    - and:
+      - string: "ESTdb2.dat"
+      - string: "QData.dat"
+      - string: /\\Estsoft\\ALFTP/

--- a/collection/file-managers/gather-alftp-information.yml
+++ b/collection/file-managers/gather-alftp-information.yml
@@ -7,6 +7,7 @@ rule:
     att&ck:
       - Credential Access::Credentials from Password Stores [T1555]
     references:
+      - https://en.wikipedia.org/wiki/ALFTP
       - https://www.altools.co.kr/Main/Default.aspx
     examples:
       - 5a2f620f29ca2f44fc22df67b674198f:0x40A257

--- a/collection/file-managers/gather-bitkinex-information.yml
+++ b/collection/file-managers/gather-bitkinex-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather bitkinex information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - http://www.bitkinex.com/ftp/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x406D14
+  features:
+    - and:
+      - string: /bitkinex\.ds/
+      - string: /\\BitKinex/

--- a/collection/file-managers/gather-blazeftp-information.yml
+++ b/collection/file-managers/gather-blazeftp-information.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: gather blazeftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.slimjet.com/blazeftp/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40C823
+  features:
+    - and:
+      - string: "BlazeFtp"
+      - string: "site.dat"
+      - or:
+        - string: "LastPassword"
+        - string: "LastAddress"
+        - string: "LastUser"
+        - string: "LastPort"
+        - string: /Software\\FlashPeak\\BlazeFtp\\Settings/

--- a/collection/file-managers/gather-bulletproof-ftp-information.yml
+++ b/collection/file-managers/gather-bulletproof-ftp-information.yml
@@ -1,0 +1,27 @@
+rule:
+  meta:
+    name: gather bulletproof-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://bpftp.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x405CCA
+  features:
+    - or:
+      - and:
+        - string: ".dat"
+        - string: ".bps"
+      - and:
+        - or:
+          - string: /Software\\BPFTP\\Bullet Proof FTP\\Main/
+          - string: /Software\\BulletProof Software\\BulletProof FTP Client\\Main/
+          - string: /Software\\BulletProof Software\\BulletProof FTP Client\\Options/
+          - string: /Software\\BPFTP\\Bullet Proof FTP\\Options/
+          - string: /Software\\BPFTP/
+        - or:
+          - string: "LastSessionFile"
+          - string: "SitesDir"

--- a/collection/file-managers/gather-classicftp-information.yml
+++ b/collection/file-managers/gather-classicftp-information.yml
@@ -1,0 +1,15 @@
+rule:
+  meta:
+    name: gather classicftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.nchsoftware.com/classic/index.html
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40735E
+  features:
+    - or:
+      - string: /Software\\NCH Software\\ClassicFTP\\FTPAccounts/

--- a/collection/file-managers/gather-coreftp-information.yml
+++ b/collection/file-managers/gather-coreftp-information.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: gather coreftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - http://www.coreftp.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x4063FD
+  features:
+    - or:
+      - string: /Software\\FTPWare\\COREFTP\\Sites/
+      - and:
+        - string: "Host"
+        - string: "User"
+        - string: "Port"
+        - string: "PthR"

--- a/collection/file-managers/gather-cuteftp-information.yml
+++ b/collection/file-managers/gather-cuteftp-information.yml
@@ -7,6 +7,7 @@ rule:
     att&ck:
       - Credential Access::Credentials from Password Stores [T1555]
     references:
+      - https://en.wikipedia.org/wiki/CuteFTP
       - https://www.globalscape.com/cuteftp
     examples:
       - 5a2f620f29ca2f44fc22df67b674198f:0x40531A

--- a/collection/file-managers/gather-cuteftp-information.yml
+++ b/collection/file-managers/gather-cuteftp-information.yml
@@ -1,0 +1,19 @@
+rule:
+  meta:
+    name: gather cuteftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.globalscape.com/cuteftp
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40531A
+  features:
+    - and:
+      - string: /\\sm\.dat/
+      - or:
+        - string: /\\GlobalSCAPE\\CuteFTP/i
+        - string: /\\GlobalSCAPE\\CuteFTP Pro/i
+        - string: /\\CuteFTP/

--- a/collection/file-managers/gather-cyberduck-information.yml
+++ b/collection/file-managers/gather-cyberduck-information.yml
@@ -1,0 +1,18 @@
+rule:
+  meta:
+    name: gather cyberduck information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://cyberduck.io/ftp/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40D965
+  features:
+    - and:
+      - string: /\\Cyberduck/
+      - or:
+        - string: "user.config"
+        - string: ".duck"

--- a/collection/file-managers/gather-direct-ftp-information.yml
+++ b/collection/file-managers/gather-direct-ftp-information.yml
@@ -1,0 +1,34 @@
+rule:
+  meta:
+    name: gather direct-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.coffeecup.com/software/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40DC62
+  features:
+    - or:
+      - string: /Software\\CoffeeCup Software\\Internet\\Profiles/
+      - string: /\\CoffeeCup Software/
+      - and:
+        - string: "Password"
+        - string: "HostName"
+        - string: "Port"
+        - string: "Username"
+        - string: "HostDirName"
+      - 2 or more:
+        - string: /\\SharedSettings\.ccs/
+        - string: /\\SharedSettings\.sqlite/
+        - string: /\\SharedSettings[0-9_\.]{2,7}\.ccs/
+        - string: /\\SharedSettings[0-9_\.]{2,7}\.sqlite/
+      - and:
+        - string: "FTP destination server"
+        - string: "FTP destination user"
+        - string: "FTP destination password"
+        - string: "FTP destination port"
+        - string: "FTP destination catalog"
+        - string: "FTP profiles"

--- a/collection/file-managers/gather-directory-opus-information.yml
+++ b/collection/file-managers/gather-directory-opus-information.yml
@@ -1,0 +1,18 @@
+rule:
+  meta:
+    name: gather directory-opus information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.gpsoft.com.au/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x4076F3
+  features:
+    - and:
+      - string: /\\GPSoftware\\Directory Opus/
+      - string: ".oxc"
+      - string: ".oll"
+      - string: "ftplast.osd"

--- a/collection/file-managers/gather-expandrive-information.yml
+++ b/collection/file-managers/gather-expandrive-information.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: gather expandrive information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.expandrive.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x407086
+  features:
+    - and:
+      - or:
+        - string: /Software\\ExpanDrive\\Sessions/
+        - string: /Software\\ExpanDrive/
+      - or:
+        - string: /ExpanDrive_Home/
+        - string: /\\drives\.js/

--- a/collection/file-managers/gather-faststone-browser-information.yml
+++ b/collection/file-managers/gather-faststone-browser-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather faststone-browser information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.faststone.org/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40E04F
+  features:
+    - and:
+      - string: /FastStone Browser/
+      - string: "FTPList.db"

--- a/collection/file-managers/gather-fasttrack-ftp-information.yml
+++ b/collection/file-managers/gather-fasttrack-ftp-information.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: gather fasttrack-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - http://www.fasttracksoft.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40F906
+  features:
+    - or:
+      - and:
+        - string: "FastTrack"
+        - string: "ftplist.txt"

--- a/collection/file-managers/gather-ffftp-information.yml
+++ b/collection/file-managers/gather-ffftp-information.yml
@@ -1,0 +1,27 @@
+rule:
+  meta:
+    name: gather ffftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - http://www2.biglobe.ne.jp/sota/ffftp-e.html
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40614B
+  features:
+    - or:
+      - and:
+        - or:
+          - string: /Software\\Sota\\FFFTP\\Options/
+          - string: /Software\\Sota\\FFFTP/
+        - or:
+          - string: /CredentialSalt/
+          - string: /CredentialCheck/
+      - and:
+        - string: "Password"
+        - string: "UserName"
+        - string: "HostAdrs"
+        - string: "RemoteDir"
+        - string: "Port"

--- a/collection/file-managers/gather-filezilla-information.yml
+++ b/collection/file-managers/gather-filezilla-information.yml
@@ -1,0 +1,33 @@
+rule:
+  meta:
+    name: gather filezilla information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://filezilla-project.org/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x4057A7
+  features:
+    - or:
+      - and:
+        - string: /\\sitemanager\.xml/
+        - string: /\\recentservers\.xml/
+        - string: /\\filezilla.xml/
+      - and:
+        - string: /Software\\FileZilla/
+        - string: "Install_Dir"
+        - string: /Software\\FileZilla Client/
+      - 3 or more:
+        - string: "Server Type"
+        - string: "Remote Dir"
+        - string: "Server.Port"
+        - string: "Server.Host"
+        - string: "Server.User"
+        - string: "Last Server Type"
+        - string: "Last Server Port"
+        - string: "Last Server User"
+        - string: "Last Server Host"
+        - string: "Last Server Pass"

--- a/collection/file-managers/gather-flashfxp-information.yml
+++ b/collection/file-managers/gather-flashfxp-information.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: gather flashfxp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.flashfxp.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x4055ED
+  features:
+    - or:
+      - and:
+        - string: /Software\\FlashFXP/
+        - string: /DataFolder/
+        - string: /Install Path/
+      - and:
+        - string: /\\Sites.dat/
+        - string: /\\Quick.dat/
+        - string: /\\History.dat/

--- a/collection/file-managers/gather-fling-ftp-information.yml
+++ b/collection/file-managers/gather-fling-ftp-information.yml
@@ -1,0 +1,21 @@
+rule:
+  meta:
+    name: gather fling-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.nchsoftware.com/fling/index.html
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x4073A7
+  features:
+    - or:
+      - string: /SOFTWARE\\NCH Software\\Fling\\Accounts/
+      - and:
+        - string: "FtpPassword"
+        - string: "_FtpPassword"
+        - string: "FtpServer"
+        - string: "FtpUserName"
+        - string: "FtpDirectory"

--- a/collection/file-managers/gather-freshftp-information.yml
+++ b/collection/file-managers/gather-freshftp-information.yml
@@ -1,0 +1,14 @@
+rule:
+  meta:
+    name: gather freshftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40C7AB
+  features:
+    - and:
+      - string: "FreshFTP"
+      - string: ".SMF"

--- a/collection/file-managers/gather-frigate3-information.yml
+++ b/collection/file-managers/gather-frigate3-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather frigate3 information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - http://www.frigate3.com/index.php
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x4069A0
+  features:
+    - and:
+      - string: /FtpSite\.xml/
+      - string: /\\Frigate3/

--- a/collection/file-managers/gather-ftp-commander-information.yml
+++ b/collection/file-managers/gather-ftp-commander-information.yml
@@ -1,0 +1,19 @@
+rule:
+  meta:
+    name: gather ftp-commander information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.ftpcommander.com/free.htm
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x405BC0
+  features:
+    - and:
+      - or:
+        - string: /FTP Navigator/
+        - string: /FTP Commander/
+      - or:
+        - string: "ftplist.txt"

--- a/collection/file-managers/gather-ftp-explorer-information.yml
+++ b/collection/file-managers/gather-ftp-explorer-information.yml
@@ -1,0 +1,27 @@
+rule:
+  meta:
+    name: gather ftp-explorer information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - http://www.ftpx.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x406915
+  features:
+    - or:
+      - and:
+        - string: /profiles\.xml/
+        - or:
+          - string: /Software\\FTP Explorer\\FTP Explorer\\Workspace\\MFCToolBar-224/
+          - string: /Software\\FTP Explorer\\Profiles/
+          - string: /\\FTP Explorer/
+      - and:
+        - string: "Password"
+        - string: "Host"
+        - string: "Login"
+        - string: "InitialPath"
+        - string: "PasswordType"
+        - string: "Port"

--- a/collection/file-managers/gather-ftp-voyager-information.yml
+++ b/collection/file-managers/gather-ftp-voyager-information.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: gather ftp-voyager information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.serv-u.com/free-tools/ftp-voyager-ftp-client-for-windows
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x408FD3
+  features:
+    - and:
+      - string: /\\RhinoSoft.com/
+      - string: "FTPVoyager.ftp"
+      - string: "FTPVoyager.qc"

--- a/collection/file-managers/gather-ftpgetter-information.yml
+++ b/collection/file-managers/gather-ftpgetter-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather ftpgetter information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.ftpgetter.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40A21C
+  features:
+    - and:
+      - string: "servers.xml"
+      - string: /\\FTPGetter/

--- a/collection/file-managers/gather-ftpinfo-information.yml
+++ b/collection/file-managers/gather-ftpinfo-information.yml
@@ -1,0 +1,19 @@
+rule:
+  meta:
+    name: gather ftpinfo information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.ftpinfo.ru/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40DF62
+  features:
+    - and:
+      - string: "ServerList.xml"
+      - string: "DataDir"
+      - or:
+        - string: /Software\\MAS-Soft\\FTPInfo\\Setup/
+        - string: /FTPInfo/

--- a/collection/file-managers/gather-ftpnow-information.yml
+++ b/collection/file-managers/gather-ftpnow-information.yml
@@ -1,0 +1,15 @@
+rule:
+  meta:
+    name: gather ftpnow information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40CFF0
+  features:
+    - and:
+      - string: "FTPNow"
+      - string: "FTP Now"
+      - string: "sites.xml"

--- a/collection/file-managers/gather-ftprush-information.yml
+++ b/collection/file-managers/gather-ftprush-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather ftprush information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.wftpserver.com/ftprush.htm
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x406AE0
+  features:
+    - and:
+      - string: /\\FTPRush/
+      - string: /RushSite\.xml/

--- a/collection/file-managers/gather-ftpshell-information.yml
+++ b/collection/file-managers/gather-ftpshell-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather ftpshell information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.ftpshell.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40DEE4
+  features:
+    - and:
+      - string: "FTPShell"
+      - string: "ftpshell.fsi"

--- a/collection/file-managers/gather-global-downloader-information.yml
+++ b/collection/file-managers/gather-global-downloader-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather global-downloader information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - http://www.actysoft.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40C732
+  features:
+    - and:
+      - string: /\\Global Downloader/
+      - string: "SM.arch"

--- a/collection/file-managers/gather-goftp-information.yml
+++ b/collection/file-managers/gather-goftp-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather goftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.goftp.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40C9E8
+  features:
+    - and:
+      - string: "GoFTP"
+      - string: "Connections.txt"

--- a/collection/file-managers/gather-leapftp-information.yml
+++ b/collection/file-managers/gather-leapftp-information.yml
@@ -1,0 +1,26 @@
+rule:
+  meta:
+    name: gather leapftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x407A33
+  features:
+    - or:
+      - and:
+        - string: "InstallPath"
+        - string: "DataDir"
+        - string: "sites.dat"
+        - string: "sites.ini"
+      - and:
+        - or:
+          - string: /SOFTWARE\\LeapWare/
+          - string: /\\LeapWare\\LeapFTP/
+        - or:
+          - 2 or more:
+            - string: "sites.dat"
+            - string: "sites.ini"
+            - string: "leapftp"

--- a/collection/file-managers/gather-netdrive-information.yml
+++ b/collection/file-managers/gather-netdrive-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather netdrive information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.netdrive.net/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x407ED1
+  features:
+    - and:
+      - string: "NDSites.ini"
+      - string: /\\NetDrive/

--- a/collection/file-managers/gather-nexusfile-information.yml
+++ b/collection/file-managers/gather-nexusfile-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather nexusfile information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.xiles.app/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40DFD1
+  features:
+    - and:
+      - string: "NexusFile"
+      - string: "ftpsite.ini"

--- a/collection/file-managers/gather-nova-ftp-information.yml
+++ b/collection/file-managers/gather-nova-ftp-information.yml
@@ -1,0 +1,15 @@
+rule:
+  meta:
+    name: gather nova-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40E5FF
+  features:
+    - or:
+      - and:
+        - string: "NovaFTP.db"
+        - string: /\\INSoftware\\NovaFTP/

--- a/collection/file-managers/gather-robo-ftp-information.yml
+++ b/collection/file-managers/gather-robo-ftp-information.yml
@@ -1,0 +1,27 @@
+rule:
+  meta:
+    name: gather robo-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.robo-ftp.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40D2CB
+  features:
+    - or:
+      - and:
+        - string: /SOFTWARE\\Robo-FTP/
+        - or:
+          - string: /\\FTPServers/
+          - string: /FTP File/
+          - string: "FTP Count"
+      - and:
+        - string: "Password"
+        - string: "ServerName"
+        - string: "UserID"
+        - string: "PortNumber"
+        - string: "InitialDirectory"
+        - string: "ServerType"

--- a/collection/file-managers/gather-securefx-information.yml
+++ b/collection/file-managers/gather-securefx-information.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: gather securefx information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.vandyke.com/products/securefx/index.html
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x4069DB
+  features:
+    - and:
+      - string: /\\Sessions/
+      - string: ".ini"
+      - string: /Config Path/
+      - or:
+        - string: /_VanDyke\\Config\\Sessions/
+        - string: /Software\\VanDyke\\SecureFX/

--- a/collection/file-managers/gather-smart-ftp-information.yml
+++ b/collection/file-managers/gather-smart-ftp-information.yml
@@ -1,0 +1,19 @@
+rule:
+  meta:
+    name: gather smart-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.smartftp.com/en-us/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x405DE8
+  features:
+    - or:
+      - and:
+        - string: /\\SmartFTP/
+        - string: ".xml"
+        - string: /Favorites\.dat/i
+        - string: /History\.dat/i

--- a/collection/file-managers/gather-softx-ftp-information.yml
+++ b/collection/file-managers/gather-softx-ftp-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather softx-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - http://www.softx.org/ftp.html
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x407685
+  features:
+    - or:
+      - string: /Software\\FTPClient\\Sites/
+      - string: /Software\\SoftX.org\\FTPClient\\Sites/

--- a/collection/file-managers/gather-southriver-webdrive-information.yml
+++ b/collection/file-managers/gather-southriver-webdrive-information.yml
@@ -1,0 +1,21 @@
+rule:
+  meta:
+    name: gather southriver-webdrive information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://southrivertech.com/products/webdriveclient/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x407F0C
+  features:
+    - or:
+      - string: /Software\\South River Technologies\\WebDrive\\Connections/
+      - and:
+        - string: "PassWord"
+        - string: "UserName"
+        - string: "RootDirectory"
+        - string: "Port"
+        - string: "ServerType"

--- a/collection/file-managers/gather-staff-ftp-information.yml
+++ b/collection/file-managers/gather-staff-ftp-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather staff-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.gsa-online.de/product/staffftp/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40C516
+  features:
+    - and:
+      - string: "Staff-FTP"
+      - string: "sites.ini"

--- a/collection/file-managers/gather-total-commander-information.yml
+++ b/collection/file-managers/gather-total-commander-information.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: gather total-commander information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.ghisler.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x404B1E
+  features:
+    - and:
+      - or:
+        - string: /Software\\Ghisler\\Total Commander/
+        - string: /Software\\Ghisler\\Windows Commander/
+      - or:
+        - string: "FtpIniName"
+        - string: "wcx_ftp.ini"
+        - string: /\\GHISLER/
+        - string: "InstallDir"

--- a/collection/file-managers/gather-turbo-ftp-information.yml
+++ b/collection/file-managers/gather-turbo-ftp-information.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: gather turbo-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.tbsoftinc.com/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x405E8B
+  features:
+    - or:
+      - and:
+        - string: "addrbk.dat"
+        - string: "quick.dat"
+      - and:
+        - string: /installpath/
+        - or:
+          - string: /Software\\TurboFTP/
+          - string: /\\TurboFTP/

--- a/collection/file-managers/gather-ultrafxp-information.yml
+++ b/collection/file-managers/gather-ultrafxp-information.yml
@@ -1,0 +1,14 @@
+rule:
+  meta:
+    name: gather ultrafxp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x406A5C
+  features:
+    - and:
+      - string: /UltraFXP/
+      - string: /\\sites\.xml/

--- a/collection/file-managers/gather-winscp-information.yml
+++ b/collection/file-managers/gather-winscp-information.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: gather winscp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://winscp.net/eng/download.php
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x407BBA
+  features:
+    - and:
+      - string: "Password"
+      - string: "HostName"
+      - string: "UserName"
+      - string: "RemoteDirectory"
+      - string: "PortNumber"
+      - string: "FSProtocol"

--- a/collection/file-managers/gather-winzip-information.yml
+++ b/collection/file-managers/gather-winzip-information.yml
@@ -1,0 +1,23 @@
+rule:
+  meta:
+    name: gather winzip information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.winzip.com/win/en/pages/old-brands/nico-mak-computing/index.html
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40E237
+  features:
+    - or:
+      - and:
+        - string: /Software\\Nico Mak Computing\\WinZip\\FTP/
+        - string: /Software\\Nico Mak Computing\\WinZip\\mru\\jobs/
+      - and:
+        - string: "Site"
+        - string: "UserID"
+        - string: "xflags"
+        - string: "Port"
+        - string: "Folder"

--- a/collection/file-managers/gather-wise-ftp-information.yml
+++ b/collection/file-managers/gather-wise-ftp-information.yml
@@ -1,0 +1,23 @@
+rule:
+  meta:
+    name: gather wise-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.wise-ftp.de/en/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x408E0D
+  features:
+    - or:
+      - and:
+        - string: "wiseftpsrvs.ini"
+        - string: "wiseftp.ini"
+        - string: "wiseftpsrvs.bin"
+      - and:
+        - string: "wiseftpsrvs.bin"
+        - or:
+          - string: /\\AceBIT/
+          - string: /Software\\AceBIT/

--- a/collection/file-managers/gather-ws-ftp-information.yml
+++ b/collection/file-managers/gather-ws-ftp-information.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: gather ws-ftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.ipswitch.com/ftp-server
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40504B
+  features:
+    - and:
+      - string: /\\Ipswitch\\WS_FTP/
+      - string: /\\win\.ini/
+      - string: /WS_FTP/

--- a/collection/file-managers/gather-xftp-information.yml
+++ b/collection/file-managers/gather-xftp-information.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: gather xftp information
+    namespace: collection/file-managers
+    author: "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores [T1555]
+    references:
+      - https://www.netsarang.com/en/xftp-download/
+    examples:
+      - 5a2f620f29ca2f44fc22df67b674198f:0x40CBEE
+  features:
+    - and:
+      - string: ".xfp"
+      - string: /\\NetSarang/


### PR DESCRIPTION
Discussed a bit in https://github.com/fireeye/capa-rules/issues/336 .  Thanks for the input @williballenthin 

> I recently worked my way through an old stealer/grabber (5a2f620f29ca2f44fc22df67b674198f) with the intent to build out capa-rules.
>
>While doing this exercise, I found that many of the rules are subjectively "low quality" relying on pairings of strings.
>
>I wanted to share these rules, in case they may be useful. I didn't roll these up into a giant PR until they received some peer review or qualitative analysis. Capa's scope (in this case, all function level) results in the rules not being too prone to FP's,
>
>Let me know if these rules would be a welcome addition to the capa-rules main repository, and if not, I'll keep a fork with supplemental rules. If a PR is decided, the rules have been linted with --thorough and capafmt has been applied.

I'll upload `5a2f620f29ca2f44fc22df67b674198f` in capa-testfiles  (https://github.com/fireeye/capa-testfiles/pull/85)

While some of these rules may be sparse, they could always serve as a placeholder if another (more robust) sample becomes available.  Some of the more obscure software doesn't have `references`, either because the company is defunct or the software is no longer available.  