### PR TITLE
ci: Update CHANGELOG automatically

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -42,10 +42,27 @@ jobs:
         # one which triggered the action)
         ref: master
         path: rules
+        fetch-depth: 100 # needed so that `git diff` finds `github.event.before`
     - name: Update rules number badge in README
       run: |
         num_rules=$(find rules -type f -name '*.yml' -not -path 'rules/.github/*' | wc -l)
         sed -i "s/rules-[0-9]*-blue\.svg/rules-$num_rules-blue.svg/" README.md
+    - name: Update number of new rules in CHANGELOG
+      run: |
+        new_rules=$(git -C rules diff -M --summary ${{ github.event.before }} | grep create | wc -l)
+        old_rules=$(grep -m 1 "### New Rules.*" CHANGELOG.md | sed -r 's/.*\((.*)\)/\1/')
+        rules=$(($old_rules + $new_rules))
+        sed -ir "0,/### New Rules.*/s//### New Rules \($rules\)/" CHANGELOG.md
+    - name: Get modified files
+      id: files
+      uses: jitterbit/get-changed-files@v1
+    - name: Add new rules to CHANGELOG
+      run: |
+        for added_file in ${{ steps.files.outputs.added }}; do
+          author=$(grep 'author:' rules/$added_file | sed 's/^.*: //' | sed 's/"//g' )
+          rule=$(echo $added_file | sed 's/\//\\\//g' | sed 's/\.yml//')
+          sed -i "0,/- *$/s//- $rule $author\n-/" CHANGELOG.md
+        done
     - name: Commit changes
       run: |
         git config user.email 'capa-dev@fireeye.com'


### PR DESCRIPTION
Update new rules in capa repository's CHANGELOG with a GitHub Action automatically with every push (for example merge of PR).

You can see how the created commit looks like here: https://github.com/Ana06/capa/commit/7d7def34548434051af318197e736f815c7658c0

And the action running here: https://github.com/Ana06/capa-rules/runs/2528333012?check_suite_focus=true

Needs https://github.com/fireeye/capa/pull/549 to be merged to work.

Related: https://github.com/fireeye/capa/issues/457.