### PR TITLE
ci: support multiple author in sync GH

### DIFF
--- a/.github/scripts/changelog_author.py
+++ b/.github/scripts/changelog_author.py
@@ -1,0 +1,12 @@
+import yaml
+import sys
+
+rule_file = sys.argv[1]
+with open(rule_file, 'r') as stream:
+    rule_yaml = yaml.safe_load(stream)
+
+author_value = rule_yaml["rule"]["meta"]["author"]
+if isinstance(author_value, list): # list of authors
+    print(" ".join(author_value))
+else: # one author
+    print(author_value)

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -56,10 +56,18 @@ jobs:
     - name: Get modified files
       id: files
       uses: jitterbit/get-changed-files@v1
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install Python dependencies
+      run:
+        pip install pyyaml
     - name: Add new rules to CHANGELOG
       run: |
         for added_file in ${{ steps.files.outputs.added }}; do
-          author=$(grep 'author:' rules/$added_file | sed 's/^.*: //' | sed 's/"//g' )
+          [[ $added_file != *.yml ]] && continue # Skip files that are not rules
+          author=$(python rules/.github/scripts/changelog_author.py rules/$added_file)
           rule=$(echo $added_file | sed 's/\//\\\//g' | sed 's/\.yml//')
           sed -i "0,/- *$/s//- $rule $author\n-/" CHANGELOG.md
         done


### PR DESCRIPTION
The sync GH action only works for a single author, producing unexpected results when using list of authors.

This change also prevent problems with new files that are not rules (`.yml`). (such as `.github/scripts/changelog_author.py`)

Closes https://github.com/fireeye/capa/issues/555