### PR TITLE
check-os-version: remove example that doesn't match anymore

### DIFF
--- a/host-interaction/os/version/check-os-version.yml
+++ b/host-interaction/os/version/check-os-version.yml
@@ -10,7 +10,6 @@ rule:
       - Discovery::System Information Discovery [T1082]
     examples:
       - 493167E85E45363D09495D0841C30648:0x401000
-      - 477743976643213d96b66ed5041a3b12:0x43CFF6
   features:
     - and:
       - or:


### PR DESCRIPTION
example is a library function that will be ignored due to FLIRT matching now.

https://github.com/fireeye/capa/issues/564