### PR TITLE
Add compiled-with-autohotkey

### DIFF
--- a/compiler/autohotkey/compiled-with-autohotkey.yml
+++ b/compiler/autohotkey/compiled-with-autohotkey.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: compiled with AutoHotKey
+    namespace: compiler/autohotkey
+    author: awillia2@cisco.com
+    scope: file
+    att&ck:
+      - Execution::Command and Scripting Interpreter [T1059]
+    references:
+      - https://www.trendmicro.com/en_us/research/20/l/stealth-credential-stealer-targets-us-canadian-bank-customers.html
+      - https://en.wikipedia.org/wiki/AutoHotkey
+    examples:
+      - 92D8EA10EA30E8B534334A1C9857A455
+  features:
+    - and:
+      - string: ">AUTOHOTKEY SCRIPT<"
+      - string: "AutoHotkeyGUI"


### PR DESCRIPTION
Add `compiled-with-autohotkey` that detects AutoHotKey executables based on simple strings present in the executables.

I added a minimized test program in https://github.com/fireeye/capa-testfiles/pull/94 but analysis on it still runs too long to pass the automated checks... Would it be worth making an exception to add that one since it should be the smallest possible for at least that version of AutoHotKey (1.1.33.02)?  Or we could not have a test file for this one and/or have it live in the nursery?

We should also add a file limitation note for this one (reference: https://github.com/fireeye/capa/issues/390)