### PR TITLE
Add packaged-as-an-inno-setup-installer

### DIFF
--- a/executable/installer/inno-setup/packaged-as-an-inno-setup-installer.yml
+++ b/executable/installer/inno-setup/packaged-as-an-inno-setup-installer.yml
@@ -1,0 +1,14 @@
+rule:
+  meta:
+    name: packaged as an Inno Setup installer
+    namespace: executable/installer/inno-setup
+    author: 'awillia2@cisco.com'
+    scope: file
+    references:
+      - https://jrsoftware.org/isinfo.php
+    examples:
+      - 70FD3347786ED7A4A43910E6778EF296
+  features:
+    - and:
+      - string: /^Inno Setup Setup Data \(/
+      - string: /^Inno Setup Messages \(/


### PR DESCRIPTION
Add `packaged-as-an-inno-setup-installer` which looks for simple strings associated with Inno Setup installers.  These strings appear to be present in installers produced using at least Inno Setup version 3 through the latest (Inno Setup version 6).

Related: https://github.com/fireeye/capa-testfiles/pull/95