### PR TITLE
ci: fix rule counting in CHANGELOG

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -49,7 +49,7 @@ jobs:
         sed -i "s/rules-[0-9]*-blue\.svg/rules-$num_rules-blue.svg/" README.md
     - name: Update number of new rules in CHANGELOG
       run: |
-        new_rules=$(git -C rules diff -M --summary ${{ github.event.before }} | grep create | wc -l)
+        new_rules=$(git -C rules diff -M --summary ${{ github.event.before }} | grep create | grep .yml | wc -l)
         old_rules=$(grep -m 1 "### New Rules.*" CHANGELOG.md | sed -r 's/.*\((.*)\)/\1/')
         rules=$(($old_rules + $new_rules))
         sed -ir "0,/### New Rules.*/s//### New Rules \($rules\)/" CHANGELOG.md


### PR DESCRIPTION
The GH action which updates the number of rules in the CHANGELOG counted files that are not `.yml`.

From https://github.com/fireeye/capa/commit/8f1ce68e96619e22ea406ee4cee3595426102c31#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed: `82 - 77 = 4` 🤯 