### PR TITLE
tighten up parse credit card rule

### DIFF
--- a/collection/credit-card/parse-credit-card-information.yml
+++ b/collection/credit-card/parse-credit-card-information.yml
@@ -9,32 +9,52 @@ rule:
     examples:
       - 1d8fd13c890060464019c0f07b928b1a:0x402860
   features:
-    - 4 or more:
-      - basic block:
+    - and:
+      - 4 or more:
+        - basic block:
+          - and:
+            - mnemonic: cmp
+            - number: 0x5E = '^' (Track 1 separator)
+        - basic block:
+          - and:
+            - mnemonic: cmp
+            - number: 0x3D = '=' (Track 2 separator)
+        - basic block:
+          - and:
+            - mnemonic: cmp
+            - number: 0x25 = '%' (Track 1 start sentinel)
+        - basic block:
+          - and:
+            - mnemonic: cmp
+            - number: 0x42 = 'B' (Format code)
+        - basic block:
+          - and:
+            - mnemonic: cmp
+            - number: 0x44 = 'D' (Format code)
+        - basic block:
+          - and:
+            - mnemonic: cmp
+            - number: 0x3F = '?' (Track 1 & 2 end sentinel)
+        - basic block:
+          - and:
+            - mnemonic: cmp
+            - number: 0x3B = ';' (Track 2 start sentinel)
+      - not:
+        - description: if a function also compares these non-hex characters it's most likely NOT parsing CC data
         - and:
-          - mnemonic: cmp
-          - number: 0x5E = '^' (Track 1 separator)
-      - basic block:
-        - and:
-          - mnemonic: cmp
-          - number: 0x3D = '=' (Track 2 separator)
-      - basic block:
-        - and:
-          - mnemonic: cmp
-          - number: 0x25 = '%' (Track 1 start sentinel)
-      - basic block:
-        - and:
-          - mnemonic: cmp
-          - number: 0x42 = 'B' (Format code)
-      - basic block:
-        - and:
-          - mnemonic: cmp
-          - number: 0x44 = 'D' (Format code)
-      - basic block:
-        - and:
-          - mnemonic: cmp
-          - number: 0x3F = '?' (Track 1 & 2 end sentinel)
-      - basic block:
-        - and:
-          - mnemonic: cmp
-          - number: 0x3B = ';' (Track 2 start sentinel)
+          - basic block:
+            - and:
+              - mnemonic: cmp
+              - number: 0x6D = 'm'
+          - basic block:
+            - and:
+              - mnemonic: cmp
+              - number: 0x6E = 'n'
+          - basic block:
+            - and:
+              - mnemonic: cmp
+              - number: 0x6F = 'o'
+          - basic block:
+            - and:
+              - mnemonic: cmp
+              - number: 0x70 = 'p'


### PR DESCRIPTION
I have come across a sample that compare with all ASCII characters, which triggers this rule (although the sample doesn't parse credit card information). Ensure that there is not a comparison with `m`, `n`, `o` and `p` (as they are in the middle of the alphabet and not part of the hex char set) to avoid this case.