### PR TITLE
Add get-domain-controller-name and enumerate-domain-computers-via-LDAP

### DIFF
--- a/anti-analysis/anti-disasm/64-bit-execution-via-heavens-gate.yml
+++ b/anti-analysis/anti-disasm/64-bit-execution-via-heavens-gate.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: 64-bit execution via heavens gate
     namespace: anti-analysis/anti-disasm
-    author: '@recvfrom'
+    author: awillia2@cisco.com
     description: Looks for instructions related to executing 64-bit code from a 32-bit process (Heaven's Gate)
     scope: function
     mbc:

--- a/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128.yml
+++ b/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: encrypt data using HC-128
     namespace: data-manipulation/encryption/hc-128
-    author: '@recvfrom'
+    author: awillia2@cisco.com
     description: Looks for instruction mnemonics associated with initialization of the HC-128 stream cipher
     scope: basic block
     att&ck:

--- a/data-manipulation/encryption/sosemanuk/encrypt-data-using-sosemanuk.yml
+++ b/data-manipulation/encryption/sosemanuk/encrypt-data-using-sosemanuk.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: encrypt data using Sosemanuk
     namespace: data-manipulation/encryption/sosemanuk
-    author: '@recvfrom'
+    author: awillia2@cisco.com
     description: Looks for cryptographic constants associated with the Sosemanuk stream cipher
     scope: basic block
     att&ck:

--- a/executable/installer/iexpress/packaged-as-an-iexpress-self-extracting-archive.yml
+++ b/executable/installer/iexpress/packaged-as-an-iexpress-self-extracting-archive.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: packaged as an IExpress self-extracting archive
     namespace: executable/installer/iexpress
-    author: '@recvfrom'
+    author: awillia2@cisco.com
     scope: file
     references:
       - https://en.wikipedia.org/wiki/IExpress

--- a/executable/installer/inno-setup/packaged-as-an-inno-setup-installer.yml
+++ b/executable/installer/inno-setup/packaged-as-an-inno-setup-installer.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: packaged as an Inno Setup installer
     namespace: executable/installer/inno-setup
-    author: 'awillia2@cisco.com'
+    author: awillia2@cisco.com
     scope: file
     references:
       - https://jrsoftware.org/isinfo.php

--- a/host-interaction/network/domain/enumerate-domain-computers-via-LDAP.yml
+++ b/host-interaction/network/domain/enumerate-domain-computers-via-LDAP.yml
@@ -1,0 +1,25 @@
+rule:
+  meta:
+    name: enumerate domain computers via LDAP
+    namespace: host-interaction/network/domain
+    author: awillia2@cisco.com
+    description: Looks for an LDAP query and related Windows API calls used to enumerate other computers on the Windows domain that a computer is connected to.
+    scope: function
+    references:
+      - https://docs.microsoft.com/en-us/windows/win32/api/adshlp/nf-adshlp-adsopenobject
+      - https://www.vkremez.com/2017/12/lets-learn-introducing-new-trickbot.html
+      - https://chuongdong.com/reverse%20engineering/2021/05/23/MountLockerRansomware/
+    att&ck:
+      - Discovery::System Network Configuration Discovery  [T1016]
+    examples:
+      - 1e2791877da02d49998dea79515a89ca:0x6CD41FF8
+      - 3808f21e56dede99bc914d90aeabe47a:0x140007144
+  features:
+    - and:
+      - or:
+        - api: activeds.ADsOpenObject
+        - api: activeds.#9
+      - string: /LDAP:\/\//
+      - or:
+        - string: /\(objectClass=computer\)/
+        - string: /\(objectCategory=computer\)/

--- a/host-interaction/network/domain/enumerate-domain-computers-via-ldap.yml
+++ b/host-interaction/network/domain/enumerate-domain-computers-via-ldap.yml
@@ -5,12 +5,12 @@ rule:
     author: awillia2@cisco.com
     description: Looks for an LDAP query and related Windows API calls used to enumerate other computers on the Windows domain that a computer is connected to.
     scope: function
+    att&ck:
+      - Discovery::System Network Configuration Discovery  [T1016]
     references:
       - https://docs.microsoft.com/en-us/windows/win32/api/adshlp/nf-adshlp-adsopenobject
       - https://www.vkremez.com/2017/12/lets-learn-introducing-new-trickbot.html
       - https://chuongdong.com/reverse%20engineering/2021/05/23/MountLockerRansomware/
-    att&ck:
-      - Discovery::System Network Configuration Discovery  [T1016]
     examples:
       - 1e2791877da02d49998dea79515a89ca:0x6CD41FF8
       - 3808f21e56dede99bc914d90aeabe47a:0x140007144

--- a/host-interaction/network/domain/get-domain-controller-name.yml
+++ b/host-interaction/network/domain/get-domain-controller-name.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: get domain controller name
+    namespace: host-interaction/network/domain
+    author: awillia2@cisco.com
+    description: Looks for calls to Windows APIs that can be used to determine the name of the domain controller for a Windows domain that a computer is connected to.
+    scope: function
+    references:
+      - https://docs.microsoft.com/en-us/windows/win32/api/lmaccess/nf-lmaccess-netgetdcname
+      - https://docs.microsoft.com/en-us/windows/win32/api/dsgetdc/nf-dsgetdc-dsgetdcnamea
+      - https://chuongdong.com/reverse%20engineering/2021/05/23/MountLockerRansomware/
+    att&ck:
+      - Discovery::System Network Configuration Discovery  [T1016]
+    examples:
+      - 3808f21e56dede99bc914d90aeabe47a:0x140007144
+  features:
+    - and:
+      - or:
+        - api: NetGetDCName
+        - api: DsGetDcName
+      - optional:
+        - api: NetApiBufferFree

--- a/host-interaction/network/domain/get-domain-controller-name.yml
+++ b/host-interaction/network/domain/get-domain-controller-name.yml
@@ -5,12 +5,12 @@ rule:
     author: awillia2@cisco.com
     description: Looks for calls to Windows APIs that can be used to determine the name of the domain controller for a Windows domain that a computer is connected to.
     scope: function
+    att&ck:
+      - Discovery::System Network Configuration Discovery  [T1016]
     references:
       - https://docs.microsoft.com/en-us/windows/win32/api/lmaccess/nf-lmaccess-netgetdcname
       - https://docs.microsoft.com/en-us/windows/win32/api/dsgetdc/nf-dsgetdc-dsgetdcnamea
       - https://chuongdong.com/reverse%20engineering/2021/05/23/MountLockerRansomware/
-    att&ck:
-      - Discovery::System Network Configuration Discovery  [T1016]
     examples:
       - 3808f21e56dede99bc914d90aeabe47a:0x140007144
   features:

--- a/host-interaction/network/domain/get-domain-information.yml
+++ b/host-interaction/network/domain/get-domain-information.yml
@@ -2,8 +2,8 @@ rule:
   meta:
     name: get domain information
     namespace: host-interaction/network/domain
-    author: '@recvfrom'
-    description: Looks for imported Windows APIs that can be used to collect information about the Windows domain that a computer is connected to.
+    author: awillia2@cisco.com
+    description: Looks for imported Windows APIs being called to collect information about the Windows domain that a computer is connected to.
     scope: function
     att&ck:
       - Discovery::System Network Configuration Discovery [T1016]

--- a/host-interaction/session/get-logon-sessions.yml
+++ b/host-interaction/session/get-logon-sessions.yml
@@ -2,8 +2,8 @@ rule:
   meta:
     name: get logon sessions
     namespace: host-interaction/session
-    author: '@recvfrom'
-    description: Looks for imported Windows APIs that can be used to enumerate user sessions.
+    author: awillia2@cisco.com
+    description: Looks for imported Windows APIs being called to enumerate user sessions.
     scope: function
     att&ck:
       - Discovery::Account Discovery [T1087]


### PR DESCRIPTION
Adds `get-domain-controller-name` and `enumerate-domain-computers-via-LDAP`, and also has some metadata updates related to rules I wrote previously

See https://github.com/fireeye/capa-testfiles/pull/98 for test files