### PR TITLE
clarify verbatim string matching

### DIFF
--- a/doc/format.md
+++ b/doc/format.md
@@ -326,9 +326,12 @@ A special character is one of:
   - a newline or other non-space whitespace (e.g. tab, CR, LF, etc), which should be represented like `string: "\n"`
   - a double quote, which should be represented as `string: "\""`
 
+capa only matches on the verbatim string, e.g. `"Mozilla"` does NOT match on `"User-Agent: Mozilla/5.0"`. Use the regex syntax described below for loose matching.
+
 Regexes should be surrounded with `/` characters. 
 By default, capa uses case-sensitive matching and assumes leading and trailing wildcards.
 To perform case-insensitive matching append an `i`. To anchor the regex at the start or end of a string, use `^` and/or `$`.
+As an example `/mozilla/i` matches on `"User-Agent: Mozilla/5.0"`.
 
 To add context to a string, use the two-line syntax `...description: DESCRIPTION STRING` shown below. The inline syntax is not supported here.
 See the [description section](#descriptions) for more details.


### PR DESCRIPTION
per #390

> ok, it was new to me, that the regular strings in capa don't do a substring search. just came from doing lots of YARA and there it's default unless you use "fullword" ;)
> 
> maybe write that explicit in the documentation, just found it here for regex, but no that's the other way around for normal strings:
> 
> ```
> Regexes should be surrounded with / characters. By default, capa uses case-sensitive matching and assumes leading and trailing wildcards. 
> ```
> 
> from https://github.com/fireeye/capa-rules/blob/master/doc/format.md

