### PR TITLE
Update clear-the-windows-event-log

### DIFF
--- a/anti-analysis/anti-forensic/clear-logs/clear-the-windows-event-log.yml
+++ b/anti-analysis/anti-forensic/clear-logs/clear-the-windows-event-log.yml
@@ -3,13 +3,17 @@ rule:
     name: clear the Windows event log
     namespace: anti-analysis/anti-forensic/clear-logs
     author: michael.hunhoff@fireeye.com
-    scope: basic block
+    scope: function
     att&ck:
       - Defense Evasion::Indicator Removal on Host::Clear Windows Event Logs [T1070.001]
     examples:
       - 82BF6347ACF15E5D883715DC289D8A2B:0x14005E0C0
+      - mimikatz.exe_:0x45228B
   features:
     - and:
-      - api: advapi32.ElfClearEventLogFile
+      - or:
+        - api: advapi32.ElfClearEventLogFile
+        - api: advapi32.ClearEventLog
       - optional:
         - api: advapi32.OpenEventLog
+        - api: advapi32.GetNumberOfEventLogRecords


### PR DESCRIPTION
Adds `ClearEventLog` to `clear-the-windows-event-log`... Also, `GetNumberOfEventLogRecords` seemed like it could fit as optional here, but I'm not completely sold on that - let me know if you think it should be left out.  Here's mimikatz using these three together:

https://github.com/gentilkiwi/mimikatz/blob/e10bde5b16b747dc09ca5146f93f2beaf74dd17a/mimikatz/modules/kuhl_m_event.c#L91-L100