### PR TITLE
adding additional detection strings to linked-against-openssl.yml

### DIFF
--- a/linking/static/openssl/linked-against-openssl.yml
+++ b/linking/static/openssl/linked-against-openssl.yml
@@ -2,7 +2,9 @@ rule:
   meta:
     name: linked against OpenSSL
     namespace: linking/static/openssl
-    author: william.ballenthin@fireeye.com
+    author:
+      - william.ballenthin@fireeye.com
+      - michael.hunhoff@fireeye.com
     scope: file
     mbc:
       - Cryptography::Crypto Library [C0059]
@@ -13,3 +15,5 @@ rule:
       - string: "RC4 for x86_64, CRYPTOGAMS by <appro@openssl.org>"
       - string: "AES for x86_64, CRYPTOGAMS by <appro@openssl.org>"
       - string: "DSA-SHA1-old"
+      - string: "OpenSSL DH Method"
+      - string: "Eric Young's PKCS#1 RSA"


### PR DESCRIPTION
closes #295.