### PR TITLE
Add glibc memfrob rule

### DIFF
--- a/data-manipulation/encryption/encrypt-data-using-memfrob-from-glibc.yml
+++ b/data-manipulation/encryption/encrypt-data-using-memfrob-from-glibc.yml
@@ -12,4 +12,6 @@ rule:
     examples:
       - 055da8e6ccfe5a9380231ea04b850e18:0x1189
   features:
-    - api: memfrob
+    - and:
+      - os: linux
+      - api: memfrob


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->

This rule detects the use of `memfrob` in glibc. I added a small binary to the test repo in https://github.com/mandiant/capa-testfiles/pull/110

I ran the thorough linter and verified the rule matched on the test sample.