### PR TITLE
parse PE header: be much more strict

### DIFF
--- a/load-code/pe/parse-pe-header.yml
+++ b/load-code/pe/parse-pe-header.yml
@@ -12,38 +12,38 @@ rule:
     # TODO filter out false positives
     - and:
       - os: windows
-      - or:
-        - and:
-          - mnemonic: cmp
-          - or:
-            - number: 0x4550 = IMAGE_NT_SIGNATURE (PE)
-            - and:
-              - number: 0x50
-              - number: 0x45
-          - or:
-            - number: 0x5A4D = IMAGE_DOS_SIGNATURE (MZ)
-            - and:
-              - number: 0x4D
-              - number: 0x5A
-        - and:
-          - offset: 0x3C = IMAGE_DOS_HEADER.e_lfanew
-          - or:
-            - and:
-              - offset/x32: 0x50 = IMAGE_NT_HEADERS.OptionalHeader.SizeOfImage
-              - offset/x32: 0x34 = IMAGE_NT_HEADERS.OptionalHeader.ImageBase
-            - and:
-              - offset/x64: 0x50 = IMAGE_NT_HEADERS64.OptionalHeader.SizeOfImage
-              - offset/x64: 0x30 = IMAGE_NT_HEADERS64.OptionalHeader.ImageBase
-        - basic block:
+      - and:
+        - mnemonic: cmp
+        - or:
+          - number: 0x4550 = IMAGE_NT_SIGNATURE (PE)
+          - and:
+            - number: 0x50
+            - number: 0x45
+        - or:
+          - number: 0x5A4D = IMAGE_DOS_SIGNATURE (MZ)
+          - and:
+            - number: 0x4D
+            - number: 0x5A
+        - optional:
           - and:
             - offset: 0x3C = IMAGE_DOS_HEADER.e_lfanew
-            - 3 or more:
-              - offset: 0x4 = IMAGE_NT_HEADERS.FileHeader.Machine
-              - offset: 0x6 = IMAGE_NT_HEADERS.FileHeader.NumberOfSections
-              - offset: 0x14 = IMAGE_NT_HEADERS.FileHeader.SizeOfOptionalHeader
-              - offset: 0x16 = IMAGE_NT_HEADERS.FileHeader.Characteristics
-              - offset: 0x28 = IMAGE_NT_HEADERS.OptionalHeader.AddressOfEntryPoint  # for 32 and 64 bit
-              - offset/x32: 0x34 = IMAGE_NT_HEADERS.OptionalHeader.ImageBase
-              - offset/x32: 0x50 = IMAGE_NT_HEADERS.OptionalHeader.SizeOfImage
-              - offset/x64: 0x30 = IMAGE_NT_HEADERS.OptionalHeader.ImageBase
-              - offset/x64: 0x50 = IMAGE_NT_HEADERS64.OptionalHeader.SizeOfImage
+            - or:
+              - and:
+                - offset/x32: 0x50 = IMAGE_NT_HEADERS.OptionalHeader.SizeOfImage
+                - offset/x32: 0x34 = IMAGE_NT_HEADERS.OptionalHeader.ImageBase
+              - and:
+                - offset/x64: 0x50 = IMAGE_NT_HEADERS64.OptionalHeader.SizeOfImage
+                - offset/x64: 0x30 = IMAGE_NT_HEADERS64.OptionalHeader.ImageBase
+          - basic block:
+            - and:
+              - offset: 0x3C = IMAGE_DOS_HEADER.e_lfanew
+              - 3 or more:
+                - offset: 0x4 = IMAGE_NT_HEADERS.FileHeader.Machine
+                - offset: 0x6 = IMAGE_NT_HEADERS.FileHeader.NumberOfSections
+                - offset: 0x14 = IMAGE_NT_HEADERS.FileHeader.SizeOfOptionalHeader
+                - offset: 0x16 = IMAGE_NT_HEADERS.FileHeader.Characteristics
+                - offset: 0x28 = IMAGE_NT_HEADERS.OptionalHeader.AddressOfEntryPoint  # for 32 and 64 bit
+                - offset/x32: 0x34 = IMAGE_NT_HEADERS.OptionalHeader.ImageBase
+                - offset/x32: 0x50 = IMAGE_NT_HEADERS.OptionalHeader.SizeOfImage
+                - offset/x64: 0x30 = IMAGE_NT_HEADERS.OptionalHeader.ImageBase
+                - offset/x64: 0x50 = IMAGE_NT_HEADERS64.OptionalHeader.SizeOfImage


### PR DESCRIPTION
strictly looking for MZ/PE constants. the other logic trees are easily fooled by access to structures of a few hundred bytes