### PR TITLE
Deleting file content via truncation

### DIFF
--- a/host-interaction/file-system/write/clear-file-content.yml
+++ b/host-interaction/file-system/write/clear-file-content.yml
@@ -9,6 +9,8 @@ rule:
       dynamic: span of calls
     mbc:
       - File System::Writes File [C0052]
+    examples:
+      - e3a6fbbc9b315141da37e5abbae05bf20aa9f48d5f569c6353360f59a0315245:0x140001450
   features:
     - and:
       - api: kernel32.SetEndOfFile


### PR DESCRIPTION
I'm not sure if `host-interaction/file-system/delete/delete-file.yml` is the correct place for this detection.

The technique is very straight forward and uses `SetEndOfFile` to clear the content of a file.

Here is an example of clearing PowerShell history using `SetEndOfFile`, https://github.com/getel-arch/Clear-ConsoleHistory/blob/main/src/main.c