### PR TITLE
use call scope for get-local-ipv4-addresses

### DIFF
--- a/host-interaction/network/address/get-local-ipv4-addresses.yml
+++ b/host-interaction/network/address/get-local-ipv4-addresses.yml
@@ -8,7 +8,7 @@ rule:
       - mehunhoff@google.com
     scopes:
       static: function
-      dynamic: span of calls
+      dynamic: call
     att&ck:
       - Discovery::System Network Configuration Discovery [T1016]
     examples:
@@ -21,11 +21,10 @@ rule:
         - api: GetAdaptersInfo
         - offset: 0x1B0 = IP_ADAPTER_INFO.IpAddressList.IpAddress
         # loop feature?
-      - call:
-        - and:
-          - api: GetAdaptersAddresses
-          - optional:
-            - or:
-              - number: 0 = AF_UNSPEC
-              - number: 2 = AF_INET
-              - number: 23 = AF_INET6
+      - and:
+        - api: GetAdaptersAddresses
+        - optional:
+          - or:
+            - number: 0 = AF_UNSPEC
+            - number: 2 = AF_INET
+            - number: 23 = AF_INET6


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
