### PR TITLE
Loosen AFD driver usage detection

### DIFF
--- a/communication/socket/tcp/create-tcp-socket-via-raw-afd-driver.yml
+++ b/communication/socket/tcp/create-tcp-socket-via-raw-afd-driver.yml
@@ -76,7 +76,7 @@ rule:
       - optional:
         - api: NtCreateFile
         - api: NtDeviceIoControlFile
-        - api: kernel32.CreateEvent 
+        - api: kernel32.CreateEvent
         - api: kernel32.WaitForSingleObject
         - number: 0x12003 = IOCTL_AFD_BIND
         - number: 0x12007 = IOCTL_AFD_CONNECT


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


## Summary 

The `communication/socket/tcp/create-tcp-socket-via-raw-afd-driver.yml` rule currently does not match many of the in-the-wild samples that utilize the same technique; this is primarily due to the required `CreateEvent`, as many of the examples hold the lock outside of the function or do not have one in the first place. 

This PR moves the `CreateEvent` to the optional scope, therefore should make more of the samples that utilize this technique to be matched.

## References
https://www.unknowncheats.me/forum/c-and-c-/500413-native-tcp-client-socket.html
418d37c488b5fc534e0ee34d3c4eab5a02ba3c3c42ca3fcc5df3ef1c6673ef62:0x0040D374

<img width="935" height="962" alt="2025-11-29_10-05-35-(vmconnect)-" src="https://github.com/user-attachments/assets/a49da73f-13f6-48ae-925b-1552eb6cae3e" />
