### PR TITLE
Add RtlRegisterWait API to shellcode exec callback

### DIFF
--- a/load-code/shellcode/execute-shellcode-via-windows-callback-function.yml
+++ b/load-code/shellcode/execute-shellcode-via-windows-callback-function.yml
@@ -82,7 +82,9 @@ rule:
         - api: ImmEnumInputContext
         - api: LdrCallEnclave
         - api: LineDDA
-        - api: RtlRegisterWait
+        - and:
+          - api: RtlRegisterWait
+          - api: SetEvent
         - and:
           - api: SymInitialize
           - or:


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


## Summary

This PR adds a largely unpopular method of shellcode execution via callback function when called via `RtlRegisterWait`.