### PR TITLE
feat(targeting): add cloud and container collection/interaction rules

### DIFF
--- a/nursery/access-aws-credentials.yml
+++ b/nursery/access-aws-credentials.yml
@@ -1,0 +1,25 @@
+rule:
+  meta:
+    name: access AWS credentials
+    namespace: collection/cloud/aws
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Credential Access::Unsecured Credentials::Credentials In Files [T1552.001]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+  features:
+    - or:
+      - string: ".aws/config"
+      - string: ".aws/credentials"
+      - string: ".aws/credentials.gpg"
+      - string: ".boto"
+      - string: ".s3backer_passwd"
+      - string: ".passwd-s3fs"
+      - string: "/etc/passwd-s3fs"
+      - string: ".s3cfg"
+      - string: "s3proxy.conf"
+      - string: ".s3ql/authinfo2"

--- a/nursery/access-cloudflare-credentials.yml
+++ b/nursery/access-cloudflare-credentials.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: access Cloudflare credentials
+    namespace: collection/cloud/other
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Credential Access::Unsecured Credentials::Credentials In Files [T1552.001]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+  features:
+    - or:
+      - string: "/etc/cloudflared/config.yml"

--- a/nursery/access-docker-credentials.yml
+++ b/nursery/access-docker-credentials.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: access Docker credentials
+    namespace: collection/container/docker
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Credential Access::Unsecured Credentials::Credentials In Files [T1552.001]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+  features:
+    - or:
+      - string: ".docker/config.json"
+      - string: ".docker/ca.pem"

--- a/nursery/access-gcp-credentials.yml
+++ b/nursery/access-gcp-credentials.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: access GCP credentials
+    namespace: collection/cloud/gcp
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Credential Access::Unsecured Credentials::Credentials In Files [T1552.001]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+  features:
+    - or:
+      - string: ".config/gcloud/access_tokens.db"
+      - string: ".config/gcloud/credentials.db"

--- a/nursery/access-kubernetes-credentials.yml
+++ b/nursery/access-kubernetes-credentials.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: access Kubernetes credentials
+    namespace: collection/container/kubernetes
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Credential Access::Unsecured Credentials::Credentials In Files [T1552.001]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+  features:
+    - or:
+      - string: "/etc/eksctl/metadata.env"

--- a/nursery/enumerate-aws-cloudformation.yml
+++ b/nursery/enumerate-aws-cloudformation.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: enumerate AWS CloudFormation
+    namespace: host-interaction/cloud/aws
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Discovery::Cloud Service Discovery [T1526]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+      - https://docs.aws.amazon.com/cli/latest/reference/cloudformation/index.html
+  features:
+    - or:
+      - string: "aws cloudformation describe-account-limits"
+      - string: "aws cloudformation describe-stacks"
+      - string: "aws cloudformation list-exports"
+      - string: "aws cloudformation list-stacks"

--- a/nursery/enumerate-aws-cloudtrail.yml
+++ b/nursery/enumerate-aws-cloudtrail.yml
@@ -1,0 +1,18 @@
+rule:
+  meta:
+    name: enumerate AWS CloudTrail
+    namespace: host-interaction/cloud/aws
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Discovery::Cloud Service Discovery [T1526]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+      - https://docs.aws.amazon.com/cli/latest/reference/cloudtrail/index.html
+  features:
+    - or:
+      - string: "aws cloudtrail describe-trails"
+      - string: "aws cloudtrail list-public-keys"

--- a/nursery/enumerate-aws-direct-connect.yml
+++ b/nursery/enumerate-aws-direct-connect.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: enumerate AWS Direct Connect
+    namespace: host-interaction/cloud/aws
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Discovery::Cloud Service Discovery [T1526]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+      - https://docs.aws.amazon.com/cli/latest/reference/directconnect/index.html
+  features:
+    - or:
+      - string: "aws directconnect describe-connections"
+      - string: "aws directconnect describe-interconnects"
+      - string: "aws directconnect describe-virtual-gateways"
+      - string: "aws directconnect describe-virtual-interfaces"

--- a/nursery/enumerate-aws-ec2.yml
+++ b/nursery/enumerate-aws-ec2.yml
@@ -1,0 +1,62 @@
+rule:
+  meta:
+    name: enumerate AWS EC2
+    namespace: host-interaction/cloud/aws
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Discovery::Cloud Service Discovery [T1526]
+      - Discovery::System Information Discovery [T1082]
+      - Discovery::System Network Configuration Discovery [T1016]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+      - https://docs.aws.amazon.com/cli/latest/reference/ec2/index.html
+  features:
+    - or:
+      - string: "aws ec2 describe-account-attributes"
+      - string: "aws ec2 describe-addresses"
+      - string: "aws ec2 describe-bundle-tasks"
+      - string: "aws ec2 describe-classic-link-instances"
+      - string: "aws ec2 describe-conversion-tasks"
+      - string: "aws ec2 describe-customer-gateways"
+      - string: "aws ec2 describe-dhcp-options"
+      - string: "aws ec2 describe-export-tasks"
+      - string: "aws ec2 describe-flow-logs"
+      - string: "aws ec2 describe-host-reservations"
+      - string: "aws ec2 describe-hosts"
+      - string: "aws ec2 describe-images"
+      - string: "aws ec2 describe-import-image-tasks"
+      - string: "aws ec2 describe-import-snapshot-tasks"
+      - string: "aws ec2 describe-instance-status"
+      - string: "aws ec2 describe-instances"
+      - string: "aws ec2 describe-internet-gateways"
+      - string: "aws ec2 describe-key-pairs"
+      - string: "aws ec2 describe-moving-addresses"
+      - string: "aws ec2 describe-nat-gateways"
+      - string: "aws ec2 describe-network-acls"
+      - string: "aws ec2 describe-network-interfaces"
+      - string: "aws ec2 describe-placement-groups"
+      - string: "aws ec2 describe-reserved-instances"
+      - string: "aws ec2 describe-reserved-instances-listings"
+      - string: "aws ec2 describe-reserved-instances-modifications"
+      - string: "aws ec2 describe-route-tables"
+      - string: "aws ec2 describe-scheduled-instances"
+      - string: "aws ec2 describe-security-groups"
+      - string: "aws ec2 describe-snapshots"
+      - string: "aws ec2 describe-spot-datafeed-subscription"
+      - string: "aws ec2 describe-spot-fleet-requests"
+      - string: "aws ec2 describe-spot-instance-requests"
+      - string: "aws ec2 describe-subnets"
+      - string: "aws ec2 describe-tags"
+      - string: "aws ec2 describe-volume-status"
+      - string: "aws ec2 describe-volumes"
+      - string: "aws ec2 describe-vpc-classic-link"
+      - string: "aws ec2 describe-vpc-classic-link-dns-support"
+      - string: "aws ec2 describe-vpc-endpoints"
+      - string: "aws ec2 describe-vpc-peering-connections"
+      - string: "aws ec2 describe-vpcs"
+      - string: "aws ec2 describe-vpn-connections"
+      - string: "aws ec2 describe-vpn-gateways"

--- a/nursery/enumerate-aws-iam.yml
+++ b/nursery/enumerate-aws-iam.yml
@@ -1,0 +1,32 @@
+rule:
+  meta:
+    name: enumerate AWS IAM
+    namespace: host-interaction/cloud/aws
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Discovery::Account Discovery::Cloud Account [T1087.004]
+      - Discovery::Permission Groups Discovery::Cloud Groups [T1069.003]
+      - Discovery::Cloud Service Discovery [T1526]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+      - https://docs.aws.amazon.com/cli/latest/reference/iam/index.html
+  features:
+    - or:
+      - string: "aws iam get-account-authorization-details"
+      - string: "aws iam get-account-password-policy"
+      - string: "aws iam get-account-summary"
+      - string: "aws iam list-account-aliases"
+      - string: "aws iam list-groups"
+      - string: "aws iam list-instance-profiles"
+      - string: "aws iam list-open-id-connect-providers"
+      - string: "aws iam list-policies"
+      - string: "aws iam list-roles"
+      - string: "aws iam list-saml-providers"
+      - string: "aws iam list-server-certificates"
+      - string: "aws iam list-users"
+      - string: "aws iam list-virtual-mfa-devices"
+      - string: "aws iam get-credential-report"

--- a/nursery/enumerate-aws-s3.yml
+++ b/nursery/enumerate-aws-s3.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: enumerate AWS S3
+    namespace: host-interaction/cloud/aws
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Discovery::Cloud Service Discovery [T1526]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+      - https://docs.aws.amazon.com/cli/latest/reference/s3/index.html
+  features:
+    - or:
+      - string: "aws s3 ls"

--- a/nursery/enumerate-aws-support-cases.yml
+++ b/nursery/enumerate-aws-support-cases.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: enumerate AWS support cases
+    namespace: host-interaction/cloud/aws
+    authors:
+      - maximemorin@google.com
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Discovery::Cloud Service Discovery [T1526]
+    references:
+      - https://unit42.paloaltonetworks.com/teamtnt-operations-cloud-environments/
+      - https://docs.aws.amazon.com/cli/latest/reference/support/index.html
+  features:
+    - or:
+      - string: "aws support describe-cases"


### PR DESCRIPTION
This adds rules for:
- enumerating AWS resources (CloudFormation, CloudTrail, DirectConnect, EC2, IAM, S3, Support)
- stealing credentials for AWS, GCP, Cloudflare
- stealing credentials for Docker and Kubernetes
- 
Rules are categorized into host-interaction and collection namespaces.