### PR TITLE
add WinSock variants for UDP socket creation

### DIFF
--- a/communication/socket/udp/create-udp-socket-winsock-variants.yml
+++ b/communication/socket/udp/create-udp-socket-winsock-variants.yml
@@ -1,0 +1,33 @@
+rule:
+  meta:
+    name: create UDP socket via WinSock variants
+    namespace: communication/socket/udp
+    authors:
+      - adityashankarkhorne@gmail.com
+    scopes:
+      static: function
+    mbc:
+      - Communication::Socket Communication::Create UDP Socket [C0001.012]
+  features:
+    - or:
+      - and:
+        - api: ws2_32.socket
+        - number: 17 = IPPROTO_UDP
+        - number: 2 = SOCK_DGRAM
+        - number: 2 = AF_INET
+      - and:
+        - api: ws2_32.WSASocket
+        - number: 17 = IPPROTO_UDP
+        - number: 2 = SOCK_DGRAM
+        - number: 2 = AF_INET
+      - and:
+        - api: ws2_32.WSASocketA
+        - number: 17 = IPPROTO_UDP
+        - number: 2 = SOCK_DGRAM
+        - number: 2 = AF_INET
+      - and:
+        - api: ws2_32.WSASocketW
+        - number: 17 = IPPROTO_UDP
+        - number: 2 = SOCK_DGRAM
+        - number: 2 = AF_INET
+      - api: socket


### PR DESCRIPTION
Summary
Adds additional WinSock API variants to improve UDP socket detection coverage.

Changes
- Added rule file: communication/socket/udp/create-udp-socket-winsock-variants.yml
  - Matches ws2_32.socket, WSASocket, WSASocketA, WSASocketW
  - Checks IPPROTO_UDP, SOCK_DGRAM, AF_INET

Why
Some malware samples create UDP sockets using alternate Winsock entry points.
This improves coverage without changing detection semantics.

Testing
- CI will run rule linter and tests.

Author: adityashankarkhorne@gmail.com
