### PR TITLE
rules: add QUIC / msquic detection rule

### DIFF
--- a/communication/quic/detect-msquic.yml
+++ b/communication/quic/detect-msquic.yml
@@ -1,0 +1,34 @@
+rule:
+  meta:
+    name: detect usage of msquic (QUIC) APIs
+    namespace: communication/quic
+    authors:
+      - adityashankarkhorne@gmail.com
+    scopes:
+      static: function
+    mbc:
+      - Communication::Network Communication::QUIC Client/Server [C0005.001]
+    examples:
+      - 05be49819139a3fdcdbddbdefd298398779521f3d68daa25275cc77508e42310.exe:0x401000
+    references:
+      - https://docs.microsoft.com/en-us/windows/win32/quic/overview
+  features:
+    - or:
+      # MsQuic APIs (Windows)
+      - api: MsQuicOpen
+      - api: MsQuicClose
+      - api: MsQuicRegistrationOpen
+      - api: MsQuicRegistrationClose
+      - api: MsQuicConfigurationOpen
+      - api: MsQuicConfigurationClose
+      - api: MsQuicConnectionOpen
+      - api: MsQuicConnectionClose
+      - api: MsQuicStreamOpen
+      - api: MsQuicStreamClose
+
+      # strings and library names (catch other implementations)
+      - string: msquic
+      - string: msquic.dll
+      - string: quiche
+      - string: ngtcp2
+      - string: "quic-go"


### PR DESCRIPTION
Summary
Adds a focused rule to detect usage of QUIC-related APIs and libraries, with emphasis on Microsoft msquic and other QUIC implementations.

Changes
- New rule: communication/quic/detect-msquic.yml
  - Matches canonical MsQuic APIs (MsQuicOpen, MsQuicRegistrationOpen, MsQuicStreamOpen, etc.)
  - Matches strings referencing msquic.dll and common QUIC implementations (quiche, ngtcp2, quic-go)

Why
QUIC is increasingly used in modern network stacks and can be abused by malware for covert C2 and data exfiltration. Covering msquic and other QUIC libs improves capa's ability to surface these behaviors.

Testing
- Includes placeholder example metadata. CI will run the rule linter and tests.

Author: adityashankarkhorne@gmail.com

Note on provenance:
This contribution was created with assistance from an AI tool (ChatGPT). I reviewed and edited the content and confirm I have the right to submit it under the project's license. I accept responsibility for the submission and its licensing.
