### PR TITLE
Fix/persistence service registry fp

### DIFF
--- a/persistence/service/persist-via-windows-service.yml
+++ b/persistence/service/persist-via-windows-service.yml
@@ -1,33 +1,51 @@
+rule:
+  meta:
+    name: persist via Windows service
+    namespace: persistence/service
+    authors:
+      - moritz.raabe@mandiant.com
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Persistence::Create or Modify System Process::Windows Service [T1543.003]
+      - Execution::System Services::Service Execution [T1569.002]
+    examples:
+      - Practical Malware Analysis Lab 03-02.dll_:0x10004706
+      - 9f012d7e3ae8f62370278e372691eb73b878fe2280b6083e1be637b278021855:0x40113A
 features:
   or:
-    # Strong indicator: service APIs
+    # -------------------------------------------------
+    # Service creation APIs (strong signal)
+    # -------------------------------------------------
     - api: advapi32.CreateServiceA
     - api: advapi32.CreateServiceW
     - api: advapi32.ChangeServiceConfigA
     - api: advapi32.ChangeServiceConfigW
     - api: advapi32.CreateServiceExA
-    
     - api: advapi32.CreateServiceExW
 
-    # Original logic: service-create with SERVICE_AUTO_START / api patterns
+    # -------------------------------------------------
+    # Original logic: CreateService + SERVICE_AUTO_START
+    # -------------------------------------------------
     - and:
       - or:
-        - and:
-          - or:
-            - basic block:
-              - and:
-                - number: 2 = SERVICE_AUTO_START
-                - api: advapi32.CreateService
-            - call:
-              - and:
-                - number: 2 = SERVICE_AUTO_START
-                - api: advapi32.CreateService
-          - optional:
-            - or:
-              - api: advapi32.OpenService
-              - api: advapi32.StartService
+        - basic block:
+          - and:
+            - number: 2 = SERVICE_AUTO_START
+            - api: advapi32.CreateService
+        - call:
+          - and:
+            - number: 2 = SERVICE_AUTO_START
+            - api: advapi32.CreateService
+      - optional:
+        - or:
+          - api: advapi32.OpenService
+          - api: advapi32.StartService
 
-    # Original logic: process/create invoking sc.exe or New-Service
+    # -------------------------------------------------
+    # Original logic: sc.exe / PowerShell New-Service
+    # -------------------------------------------------
     - and:
       - match: host-interaction/process/create
       - or:
@@ -37,10 +55,13 @@ features:
         - string: /^sc(|\.exe) create/i
         - string: /New-Service /i
 
-    # Tight registry-based persistence: only ImagePath / Start / Type under Service keys
+    # -------------------------------------------------
+    # FIXED registry-based persistence (no FP)
+    # -------------------------------------------------
     - and:
       - match: host-interaction/registry/set-value
       - or:
         - string: /SYSTEM\\CurrentControlSet\\Services\\[^\\]+\\ImagePath/i
         - string: /SYSTEM\\CurrentControlSet\\Services\\[^\\]+\\Start(?![A-Za-z0-9_])/i
         - string: /SYSTEM\\CurrentControlSet\\Services\\[^\\]+\\Type(?![A-Za-z0-9_])/i
+


### PR DESCRIPTION
Fixes issue #1100 — previous rule matched any registry writes under
SYSTEM\CurrentControlSet\Services\* and produced false positives
(e.g. NetBT\Parameters\Interfaces\Tcpip_* -> NetbiosOptions).

This patch tightens registry-based detection so we only flag persistence
when service APIs are used (CreateService/ChangeServiceConfig) or when
registry writes target canonical persistence values:

- ImagePath
- Start
- Type

This preserves detection of true service persistence while preventing
fp hits on network configuration edits.  Added sample hash to examples
for reviewer context.

Notes: recommend adding CI checks to require examples and negative tests
for registry-based persistence rules.
