### PR TITLE
add word boundary to del regex to prevent false positives

### DIFF
--- a/anti-analysis/anti-forensic/self-deletion/self-delete.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete.yml
@@ -21,9 +21,9 @@ rule:
         - string: "cmd.exe"
         - match: host-interaction/process/create
       - or:
-        - string: /\/c\s*del\s*/
+        - string: /\/c\s*\bdel\b\s*/
           description: "/c del"
-        - string: /(^|[\&;\|]\s*)del\b(\s.*)?/i
+        - string: /(^|[\&;\|]\s*)\bdel\b(\s.*)?/i
           description: "echo 1&&del /path/to/file"
       - optional:
         - string: /\s*>\s*nul\s*/i

--- a/anti-analysis/anti-forensic/self-deletion/self-delete.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete.yml
@@ -23,7 +23,7 @@ rule:
       - or:
         - string: /\/c\s*del\s*/
           description: "/c del"
-        - string: /(^|[\&;\|]\s*)del(\s.*)?/i
+        - string: /(^|[\&;\|]\s*)del\b(\s.*)?/i
           description: "echo 1&&del /path/to/file"
       - optional:
         - string: /\s*>\s*nul\s*/i


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->

Closes #1089 
- Added a word boundary `\b` after `del` to ensure the pattern only matches the `del` shell command as a standalone token 
- updated rule passes linting.