### PR TITLE
improve Heaven's Gate detection for computed selector variants

### DIFF
--- a/anti-analysis/anti-disasm/64-bit-execution-via-heavens-gate.yml
+++ b/anti-analysis/anti-disasm/64-bit-execution-via-heavens-gate.yml
@@ -13,21 +13,40 @@ rule:
     references:
       - https://download.bitdefender.com/resources/files/News/CaseStudies/study/318/Bitdefender-TRR-Whitepaper-Maze-creat4351-en-EN-GenericUse.pdf
       - https://www.malwaretech.com/2014/02/the-0x33-segment-selector-heavens-gate.html
+      - https://github.com/mandiant/capa-rules/issues/1096
     examples:
       - 79abd17391adc6251ecdc58d13d76baf:0x10002385
   features:
     - and:
+      - arch: i386
       - or:
-        - description: set up retf to push 0x33 to CS indicating 64-bit mode
-        - instruction:
-          - mnemonic: push
-          - number: 0x33
-        - instruction:
-          - mnemonic: mov
-          - number: 0x33
-      - characteristic: call $+5
-        description: call $+5 pushes the current EIP onto the stack, +5 to jump past call insn bytes
-      - instruction:
-        - mnemonic: add = 'add dword ptr[esp], 5' updates the return address to point after retf
-        - number: 0x5 = length of add + retf insn bytes
-      - mnemonic: retf = set EIP = [ESP] and CS = [ESP+4]
+        - and:
+          - description: set up retf to push 0x33 to CS indicating 64-bit mode
+          - or:
+            - instruction:
+              - mnemonic: push
+              - number: 0x33
+            - instruction:
+              - mnemonic: mov
+              - number: 0x33
+          - characteristic: call $+5
+            description: call $+5 pushes the current EIP onto the stack, +5 to jump past call insn bytes
+          - instruction:
+            - mnemonic: add = 'add dword ptr[esp], 5' updates the return address to point after retf
+            - number: 0x5 = length of add + retf insn bytes
+          - mnemonic: retf = set EIP = [ESP] and CS = [ESP+4]
+        - and:
+          - description: obfuscated variant computes selector 0x33 at runtime then transitions using retf
+          - instruction:
+            - mnemonic: push
+            - number: 0x3
+          - instruction:
+            - mnemonic: shl
+            - number: 0x4
+          - instruction:
+            - mnemonic: add
+            - number: 0x3
+          - instruction:
+            - mnemonic: push
+            - number: 0x0
+          - mnemonic: retf


### PR DESCRIPTION
This PR improves detection for `64-bit execution via heavens gate` to cover obfuscated variants where the `0x33` selector is computed at runtime instead of used as an immediate constant.

Fixes #1096.

### Rule logic updates

1. Kept the existing strong pattern (`call $+5` + `add [esp], 5` + `retf`) and corrected the selector setup clause to properly allow either:
   - `push 0x33`, or
   - `mov 0x33`

2. Added a conservative secondary branch for the obfuscated selector construction pattern:
   - `push 0x3`
   - `shl ... , 0x4`
   - `add ... , 0x3`
   - `push 0x0`
   - `retf`

3. Added a reference to issue #1096 in `meta.references`.

## Validation

- `capafmt` passed for the updated rule.
- `lint --thorough -t "64-bit execution via heavens gate"` passed.
- Rule still matches referenced example:
  - `tests/data/79abd17391adc6251ecdc58d13d76baf.dll_`
- Negative sanity check:
  - `tests/data/mimikatz.exe_` -> no match for this rule.