### PR TITLE
add general BITS usage detection

### DIFF
--- a/communication/http/client/create-bits-job.yml
+++ b/communication/http/client/create-bits-job.yml
@@ -5,7 +5,7 @@ rule:
     namespace: communication/http/client
     authors:
       - "@mr-tz"
-    description: BITS jobs can be used to download data or achieve persistence (via SetNotifyCmdLine)
+    description: create a Windows BITS job via COM or command-line tooling
     scopes:
       static: function
       dynamic: unsupported  # requires offset, bytes features
@@ -17,13 +17,10 @@ rule:
     examples:
       - 08ac667c65d36d6542917655571e61c8.exe_:0x401E78
   features:
-    - and:
+    - or:
       - and:
         - bytes: 0D 4C E3 5C C9 0D 1F 4C 89 7C DA A1 B7 8C EE 7C = IBackgroundCopyManager
         - bytes: 4B D3 91 49 A1 80 91 42 83 B6 33 28 36 6B 90 97 = BITS_ControlClass
         - offset: 0xC = IBackgroundCopyManagerVtbl.CreateJob
-        - offset: 0x10 = IBackgroundCopyJobVtbl.AddFile
-      - optional:
-        - description: SetNotifyCmdLine may be use to persist
-        - bytes: 39 07 B5 54 6F 68 EB 45 9D FF D6 A9 A0 FA A9 AF = IBackgroundCopyJob2
-        - offset: 0x8C = IBackgroundCopyJob2Vtbl.SetNotifyCmdLine
+      - string: /\bbitsadmin(?:\.exe)?\b.{0,80}\b\/create\b/i
+      - string: /\bStart-BitsTransfer\b/i

--- a/communication/http/client/transfer-files-via-bits.yml
+++ b/communication/http/client/transfer-files-via-bits.yml
@@ -1,0 +1,26 @@
+rule:
+  meta:
+    name: transfer files via BITS
+    namespace: communication/http/client
+    authors:
+      - akshat4703
+    description: transfer files using a BITS job
+    scopes:
+      static: function
+      dynamic: unsupported  # requires offset, bytes features
+    att&ck:
+      - Defense Evasion::BITS Jobs [T1197]
+    references:
+      - https://cloud.google.com/blog/topics/threat-intelligence/attacker-use-of-windows-background-intelligent-transfer-service/
+      - https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/bitsadmin
+      - https://learn.microsoft.com/en-us/powershell/module/bitstransfer/start-bitstransfer
+    examples:
+      - 08ac667c65d36d6542917655571e61c8.exe_:0x401E78
+  features:
+    - and:
+      - match: create BITS job
+      - or:
+        - offset: 0x10 = IBackgroundCopyJobVtbl.AddFile
+        - string: /\bbitsadmin(?:\.exe)?\b.{0,80}\b\/addfile\b/i
+        - string: /\bbitsadmin(?:\.exe)?\b.{0,80}\b\/transfer\b/i
+        - string: /\bSet-BitsTransfer\b/i

--- a/nursery/persist-via-bits-job.yml
+++ b/nursery/persist-via-bits-job.yml
@@ -16,10 +16,10 @@ rule:
       - match: host-interaction/process/create
       - or:
         - and:
-          - string: /bitsadmin(|\.exe) /i
-          - string: /\/SetNotifyCmdLine/i
+          - string: /\bbitsadmin(?:\.exe)?\b/i
+          - string: /\b\/SetNotifyCmdLine\b/i
         - and:
           - or:
-            - string: /Set-BitsTransfer /i
-            - string: /Start-BitsTransfer /i
-          - string: / -NotifyCmdLine /i
+            - string: /\bSet-BitsTransfer\b/i
+            - string: /\bStart-BitsTransfer\b/i
+          - string: /\b-NotifyCmdLine\b/i

--- a/nursery/persist-via-pendingfilerenameoperations-registry-value.yml
+++ b/nursery/persist-via-pendingfilerenameoperations-registry-value.yml
@@ -1,0 +1,21 @@
+rule:
+  meta:
+    name: persist via PendingFileRenameOperations registry value
+    namespace: persistence/registry
+    authors:
+      - akshat4703
+    description: persist by queuing file rename or delete operations via Session Manager at next reboot
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Persistence::Boot or Logon Autostart Execution::Registry Run Keys / Startup Folder [T1547.001]
+    references:
+      - https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexa
+      - https://forensicatorj.wordpress.com/2014/06/25/interpreting-the-pendingfilerenameoperations-registry-key-for-forensics/
+    examples:
+      - ac742739cae0d411dfcb78ae99a7baee:0x140002318
+  features:
+    - and:
+      - match: set registry value
+      - string: /\bSystem\\(ControlSet\d{3}|CurrentControlSet)\\Control\\Session Manager\\PendingFileRenameOperations\b/i


### PR DESCRIPTION
**Summary**
Implements #967 by adding a general rule to detect usage of BITS (Background Intelligent Transfer Service).

**What Changed**
Added:
rules/communication/http/client/use-bits.yml

The rule detects:
COM-based BITS usage via the existing create BITS job rule

Command-line BITS usage such as bitsadmin, Start-BitsTransfer, or Set-BitsTransfer when process creation behavior is observed

**Validation**

capafmt passed
lint --thorough -t "use BITS" rules passed