### PR TITLE
broaden ITaskService scheduled-task detection for .NET TaskService usage

### DIFF
--- a/nursery/schedule-task-via-itaskservice.yml
+++ b/nursery/schedule-task-via-itaskservice.yml
@@ -10,7 +10,6 @@ rule:
     att&ck:
       - Persistence::Scheduled Task/Job::Scheduled Task [T1053.005]
     references:
-      - https://github.com/mandiant/capa-rules/issues/959
       - https://learn.microsoft.com/en-us/windows/win32/taskschd/taskservice
   features:
     - or:
@@ -25,7 +24,7 @@ rule:
         - or:
           - string: /Microsoft\.Win32\.TaskScheduler\.TaskService/i
           - string: /TaskScheduler\.TaskService/i
-          - string: /Schedule\.Service/i
+          - string: /\bSchedule\.Service\b/i
         - or:
-          - string: /RegisterTaskDefinition/i
-          - string: /NewTask/i
+          - string: /\bRegisterTaskDefinition\b/i
+          - string: /\bNewTask\b/i

--- a/nursery/schedule-task-via-itaskservice.yml
+++ b/nursery/schedule-task-via-itaskservice.yml
@@ -9,11 +9,23 @@ rule:
       dynamic: unsupported  # requires offset, bytes features
     att&ck:
       - Persistence::Scheduled Task/Job::Scheduled Task [T1053.005]
+    references:
+      - https://github.com/mandiant/capa-rules/issues/959
+      - https://learn.microsoft.com/en-us/windows/win32/taskschd/taskservice
   features:
-    - and:
-      - basic block:
-        - and:
-          - api: ole32.CoCreateInstance
-          - bytes: 9F 36 87 0F E5 A4 FC 4C BD 3E 73 E6 15 45 72 DD = CLSID_TaskScheduler
-          - bytes: C7 A4 AB 2F A9 4D 13 40 96 97 20 CC 3F D4 0F 85 = IID_ITaskService
-      - offset: 0x24 = ppv->NewTask
+    - or:
+      - and:
+        - basic block:
+          - and:
+            - api: ole32.CoCreateInstance
+            - bytes: 9F 36 87 0F E5 A4 FC 4C BD 3E 73 E6 15 45 72 DD = CLSID_TaskScheduler
+            - bytes: C7 A4 AB 2F A9 4D 13 40 96 97 20 CC 3F D4 0F 85 = IID_ITaskService
+        - offset: 0x24 = ppv->NewTask
+      - and:
+        - or:
+          - string: /Microsoft\.Win32\.TaskScheduler\.TaskService/i
+          - string: /TaskScheduler\.TaskService/i
+          - string: /Schedule\.Service/i
+        - or:
+          - string: /RegisterTaskDefinition/i
+          - string: /NewTask/i


### PR DESCRIPTION
**Summary**
Updated the rule for scheduling tasks via ITaskService.

**What Changed**
Updated:
rules/nursery/schedule-task-via-itaskservice.yml

Changes include:
Added references to issue #959 and official TaskService documentation

Broadened detection logic:
kept existing COM/GUID-based ITaskService detection

added .NET TaskService string-based detection:
Microsoft.Win32.TaskScheduler.TaskService / TaskScheduler.TaskService / Schedule.Service combined with RegisterTaskDefinition or NewTask

**Validation**
capafmt passed
lint --thorough -t "schedule task via ITaskService" passed