### PR TITLE
Add nursery rules for Linux kernel rootkit techniques

### DIFF
--- a/nursery/escalate-privileges-via-commit_creds-on-linux.yml
+++ b/nursery/escalate-privileges-via-commit_creds-on-linux.yml
@@ -1,0 +1,21 @@
+rule:
+  meta:
+    name: escalate privileges via commit_creds on Linux
+    namespace: host-interaction/privilege
+    authors:
+      - Aryan Khandhadiya
+    description: detect Linux kernel modules that escalate privileges using prepare_kernel_cred and commit_creds, a technique commonly used by rootkits
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Privilege Escalation::Exploitation for Privilege Escalation [T1068]
+    references:
+      - https://inferi.club/post/the-art-of-linux-kernel-rootkits
+      - https://www.kernel.org/doc/html/latest/security/credentials.html
+
+  features:
+    - and:
+      - os: linux
+      - api: prepare_kernel_cred
+      - api: commit_creds

--- a/nursery/escalate-privileges-via-commit_creds-on-linux.yml
+++ b/nursery/escalate-privileges-via-commit_creds-on-linux.yml
@@ -1,19 +1,18 @@
 rule:
   meta:
     name: escalate privileges via commit_creds on Linux
-    namespace: host-interaction/privilege
+    namespace: host-interaction/process/modify
     authors:
-      - Aryan Khandhadiya
+      - aryanyk
     description: detect Linux kernel modules that escalate privileges using prepare_kernel_cred and commit_creds, a technique commonly used by rootkits
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Privilege Escalation::Exploitation for Privilege Escalation [T1068]
     references:
       - https://inferi.club/post/the-art-of-linux-kernel-rootkits
       - https://www.kernel.org/doc/html/latest/security/credentials.html
-
   features:
     - and:
       - os: linux

--- a/nursery/register-netfilter-hook-on-linux.yml
+++ b/nursery/register-netfilter-hook-on-linux.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: register Netfilter hook on Linux
+    namespace: host-interaction/network
+    authors:
+      - Aryan Khandhadiya
+    description: kernel rootkits can register Netfilter hooks to inspect or modify packet flow
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Defense Evasion::Impair Defenses [T1562]
+    references:
+      - https://inferi.club/post/the-art-of-linux-kernel-rootkits
+      - https://www.kernel.org/doc/html/latest/networking/netfilter.html
+
+  features:
+    - and:
+      - os: linux
+      - or:
+        - api: nf_register_net_hook
+        - api: nf_register_hook

--- a/nursery/register-netfilter-hook-on-linux.yml
+++ b/nursery/register-netfilter-hook-on-linux.yml
@@ -3,17 +3,16 @@ rule:
     name: register Netfilter hook on Linux
     namespace: host-interaction/network
     authors:
-      - Aryan Khandhadiya
+      - aryanyk
     description: kernel rootkits can register Netfilter hooks to inspect or modify packet flow
     scopes:
-      static: function
+      static: instruction
       dynamic: call
     att&ck:
       - Defense Evasion::Impair Defenses [T1562]
     references:
       - https://inferi.club/post/the-art-of-linux-kernel-rootkits
       - https://www.kernel.org/doc/html/latest/networking/netfilter.html
-
   features:
     - and:
       - os: linux


### PR DESCRIPTION
Fixes #998

### Description

This PR adds two new **nursery rules** for detecting Linux kernel rootkit techniques.

The first rule detects privilege escalation patterns commonly used in Linux kernel rootkits where elevated credentials are created using `prepare_kernel_cred` and applied via `commit_creds`.

The second rule detects registration of Netfilter hooks through `nf_register_net_hook` or `nf_register_hook`, which can be used by kernel modules to intercept or modify network traffic.

Both rules target Linux kernel module behavior that may indicate rootkit activity.

### Rules Added

1. **escalate privileges via commit_creds on Linux**
   Detects the use of the `prepare_kernel_cred` → `commit_creds` API pattern frequently used by kernel rootkits to escalate privileges.

2. **register Netfilter hook on Linux**
   Detects the registration of Netfilter hooks (`nf_register_net_hook` or `nf_register_hook`) that may be used to inspect or manipulate packet flow.

### Testing

The rules were validated using the capa linting utilities.

Commands used:

```
python ../capa/scripts/lint.py -t "escalate privileges via commit_creds on Linux" -v .
python ../capa/scripts/lint.py -t "register Netfilter hook on Linux" -v .
```

Both rules pass lint checks.
Examples are not included yet, so the rules remain in the **nursery** directory.

### References

* https://inferi.club/post/the-art-of-linux-kernel-rootkits
* https://www.kernel.org/doc/html/latest/security/credentials.html
* https://www.kernel.org/doc/html/latest/networking/netfilter.html

### AI Usage

AI tools were used to assist with drafting rule descriptions and refining rule structure. All rule logic and validation steps were reviewed and tested manually.
