### PR TITLE
Add .NET Environment.TickCount timing anti-debug rule

### DIFF
--- a/nursery/check-for-time-delay-in-dotnet.yml
+++ b/nursery/check-for-time-delay-in-dotnet.yml
@@ -1,0 +1,24 @@
+rule:
+  meta:
+    name: check for time delay in .NET
+    namespace: anti-analysis/anti-debugging/debugger-detection
+    authors:
+      - "@aryanyk"
+    description: detects potential debugger checks by comparing Environment.TickCount values around Thread.Sleep calls.
+    scopes:
+      static: function
+      dynamic: unsupported  # relies on static analysis of IL property access and timing patterns
+    att&ck:
+      - Defense Evasion::Virtualization/Sandbox Evasion [T1497]
+    mbc:
+      - Anti-Behavioral Analysis::Debugger Detection::Timing/Delay Check GetTickCount [B0001.032]
+    references:
+      - https://github.com/Outbuilt/.NET-Anti-Debug
+    examples:
+      - e842958188274d5ffee7fbeffb803b2e:0x6000001
+
+  features:
+    - and:
+      - format: dotnet
+      - api: System.Threading.Thread::Sleep
+      - count(property(System.Environment::TickCount)): 2 or more

--- a/nursery/check-for-time-delay-in-dotnet.yml
+++ b/nursery/check-for-time-delay-in-dotnet.yml
@@ -1,7 +1,7 @@
 rule:
   meta:
     name: check for time delay in .NET
-    namespace: anti-analysis/anti-debugging/debugger-detection
+    namespace: anti-analysis/anti-debugging
     authors:
       - "@aryanyk"
     description: detects potential debugger checks by comparing Environment.TickCount values around Thread.Sleep calls.

--- a/nursery/check-for-time-delay-in-dotnet.yml
+++ b/nursery/check-for-time-delay-in-dotnet.yml
@@ -16,7 +16,6 @@ rule:
       - https://github.com/Outbuilt/.NET-Anti-Debug
     examples:
       - e842958188274d5ffee7fbeffb803b2e:0x6000001
-
   features:
     - and:
       - format: dotnet


### PR DESCRIPTION
This PR adds a rule to detect timing-based anti-debug checks in .NET binaries that rely on repeated reads of `Environment.TickCount` around `Thread.Sleep`.

Issue #596 

The technique appears in the `.NET-Anti-Debug` project. A minimal sample implementing the behavior was compiled, features were inspected using `scripts/show-features.py`, and the rule was verified to trigger correctly with capa.

Example detection:

* md5: e842958188274d5ffee7fbeffb803b2e
* function: 0x6000001

Additional rules for other techniques in the same project (e.g., WMI-based VM detection and process enumeration) will be submitted in follow-up PRs after validating samples.
