### PR TITLE
dump-lsass-memory-via-openprocess-and-minidumpwritedump

### DIFF
--- a/nursery/dump-lsass-memory-via-openprocess-and-minidumpwritedump.yml
+++ b/nursery/dump-lsass-memory-via-openprocess-and-minidumpwritedump.yml
@@ -1,0 +1,30 @@
+rule:
+  meta:
+    name: dump LSASS memory via OpenProcess and MiniDumpWriteDump
+    namespace: collection/credential-dumping
+    authors:
+      - akshatpal
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Credential Access::OS Credential Dumping::LSASS Memory [T1003.001]
+    references:
+      - https://attack.mitre.org/techniques/T1003/001/
+      - https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocess
+      - https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/nf-minidumpapiset-minidumpwritedump
+  features:
+    - and:
+      - or:
+        - match: open process
+        - api: kernel32.OpenProcess
+        - api: NtOpenProcess
+        - api: ZwOpenProcess
+      - or:
+        - match: create process memory minidump
+        - api: dbghelp.MiniDumpWriteDump
+      - or:
+        - substring: "lsass.exe"
+        - substring: "\\lsass.exe"
+      - optional:
+        - match: acquire debug privileges


### PR DESCRIPTION
### Summary
Add a rule to detect attempts to access **LSASS** and create a memory dump.

Many credential-stealing tools and malware families dump the **Local Security Authority Subsystem Service (LSASS)** process to extract credentials. This capability can often be identified by combining LSASS process discovery with APIs used to open the process and write a memory dump.

---

### Motivation
Dumping LSASS memory is a common credential-access technique used by tools such as Mimikatz and many commodity malware families. Detecting this behavior would improve capa’s ability to identify credential-theft capabilities in analyzed binaries.

---

### Proposed Detection Logic

The rule should look for a combination of signals related to LSASS discovery, process access, and dumping behavior.

#### 1. LSASS Process Discovery
- `string: lsass.exe`
- possible path references to LSASS

#### 2. Process Access
- `OpenProcess`
- `NtOpenProcess`
- relevant process access rights such as:
  - `PROCESS_VM_READ`
  - `PROCESS_QUERY_INFORMATION`

#### 3. Dump Creation
- `MiniDumpWriteDump`
- usage of `DbgHelp` functions associated with process dumping

#### 4. Additional Variant
Some implementations open LSASS via duplicated handles instead of directly calling `OpenProcess`.  
The rule could also account for flows involving:

- `DuplicateHandle`
- handle inheritance or duplication patterns prior to dump creation

---

### False Positive Reduction
To avoid overly broad matches, the rule should require **at least two independent signals**, such as:

- LSASS discovery + process opening API  
- process opening API + `MiniDumpWriteDump`  
- LSASS string + dump API usage  

This multi-signal requirement should help reduce false positives in legitimate debugging tools.

---

### Example Capability
Credential dumping via LSASS process memory access.

---

### Potential Rule Scope
Function scope or file scope depending on feature availability and matching reliability.

---

### Notes
This rule focuses on identifying the **behavior of accessing and dumping LSASS**, rather than detecting specific tools.