### PR TITLE
add ProcDump-based LSASS memory dump detection

### DIFF
--- a/nursery/dump-lsass-memory-via-minidumpwritedump.yml
+++ b/nursery/dump-lsass-memory-via-minidumpwritedump.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: dump LSASS memory via OpenProcess and MiniDumpWriteDump
+    name: dump LSASS memory via MiniDumpWriteDump
     namespace: collection/credential-dumping
     authors:
       - akshatpal
@@ -11,16 +11,11 @@ rule:
       - Credential Access::OS Credential Dumping::LSASS Memory [T1003.001]
     references:
       - https://attack.mitre.org/techniques/T1003/001/
-      - https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocess
       - https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/nf-minidumpapiset-minidumpwritedump
     examples:
-      - 91a12a4cf437589ba70b1687f5acad19:0x43E1C9
+      - 91a12a4cf437589ba70b1687f5acad19
   features:
     - and:
-      - match: open process
       - match: create process memory minidump
-      - or:
-        - substring: "lsass.exe"
-        - substring: "\\lsass.exe"
       - optional:
-        - match: acquire debug privileges
+        - string: /\\?lsass(\.exe)?/i

--- a/nursery/dump-lsass-memory-via-openprocess-and-minidumpwritedump.yml
+++ b/nursery/dump-lsass-memory-via-openprocess-and-minidumpwritedump.yml
@@ -1,0 +1,26 @@
+rule:
+  meta:
+    name: dump LSASS memory via OpenProcess and MiniDumpWriteDump
+    namespace: collection/credential-dumping
+    authors:
+      - akshatpal
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Credential Access::OS Credential Dumping::LSASS Memory [T1003.001]
+    references:
+      - https://attack.mitre.org/techniques/T1003/001/
+      - https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocess
+      - https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/nf-minidumpapiset-minidumpwritedump
+    examples:
+      - 91a12a4cf437589ba70b1687f5acad19:0x43E1C9
+  features:
+    - and:
+      - match: open process
+      - match: create process memory minidump
+      - or:
+        - substring: "lsass.exe"
+        - substring: "\\lsass.exe"
+      - optional:
+        - match: acquire debug privileges

--- a/nursery/dump-lsass-memory-via-procdump.yml
+++ b/nursery/dump-lsass-memory-via-procdump.yml
@@ -1,0 +1,29 @@
+rule:
+  meta:
+    name: dump LSASS memory via ProcDump
+    namespace: collection/credential-dumping
+    authors:
+      - akshatpal
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Credential Access::OS Credential Dumping::LSASS Memory [T1003.001]
+    references:
+      - https://attack.mitre.org/techniques/T1003/001/
+      - https://learn.microsoft.com/en-us/sysinternals/downloads/procdump
+      - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Procdump/
+  features:
+    - and:
+      - match: host-interaction/process/create
+      - or:
+        - string: /procdump(64)?(\.exe)?/i
+        - string: /sysinternals\\procdump(64)?(\.exe)?/i
+      - string: /lsass(\.exe)?/i
+      - or:
+        - string: / -ma(\s|$)/i
+        - string: / -mm(\s|$)/i
+        - string: / -mp(\s|$)/i
+        - string: /\.dmp(\s|$)/i
+      - optional:
+        - string: /-accepteula/i

--- a/nursery/dump-lsass-memory-via-procdump.yml
+++ b/nursery/dump-lsass-memory-via-procdump.yml
@@ -13,6 +13,8 @@ rule:
       - https://attack.mitre.org/techniques/T1003/001/
       - https://learn.microsoft.com/en-us/sysinternals/downloads/procdump
       - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Procdump/
+    examples:
+      - 91a12a4cf437589ba70b1687f5acad19:0x43E1C9
   features:
     - and:
       - match: host-interaction/process/create

--- a/nursery/dump-lsass-memory-via-procdump.yml
+++ b/nursery/dump-lsass-memory-via-procdump.yml
@@ -13,19 +13,13 @@ rule:
       - https://attack.mitre.org/techniques/T1003/001/
       - https://learn.microsoft.com/en-us/sysinternals/downloads/procdump
       - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Procdump/
-    examples:
-      - 91a12a4cf437589ba70b1687f5acad19:0x43E1C9
   features:
     - and:
       - match: host-interaction/process/create
-      - or:
-        - string: /procdump(64)?(\.exe)?/i
-        - string: /sysinternals\\procdump(64)?(\.exe)?/i
+      - string: /(?:sysinternals\\)?procdump(64)?(\.exe)?/i
       - string: /lsass(\.exe)?/i
       - or:
         - string: / -ma(\s|$)/i
         - string: / -mm(\s|$)/i
         - string: / -mp(\s|$)/i
         - string: /\.dmp(\s|$)/i
-      - optional:
-        - string: /-accepteula/i


### PR DESCRIPTION
## Summary
Add a new **nursery rule** to detect **LSASS memory dumping using ProcDump** based on command execution patterns.

The rule identifies behavior where ProcDump is used to create a memory dump of the `lsass` process, which is a common technique used by attackers to extract Windows credentials.

---

## What Changed
Added a new rule:

- `dump-lsass-memory-via-procdump.yml`

The rule matches when the following indicators appear together:

- **Process creation behavior**  
  `match: host-interaction/process/create`

- **ProcDump execution indicator**  
  `procdump` or `procdump64` (with optional `.exe`)

- **LSASS process target**  
  `lsass` or `lsass.exe`

- **Dump-related arguments or output**  
  `-ma`, `-mm`, `-mp`, or `.dmp`

Optional command-line arguments supported:

- `-accepteula`

Requiring multiple signals helps reduce false positives while capturing realistic attacker usage patterns.

---

## Why
ProcDump is frequently abused as a **LOLBin** to dump memory from the **LSASS (Local Security Authority Subsystem Service)** process. Attackers can then extract credentials from the dump using tools such as **Mimikatz**.

This rule helps identify that behavior by matching common ProcDump command-line patterns targeting LSASS.

Example attacker command:

```
procdump -ma lsass.exe lsass.dmp
```

---

## ATT&CK Mapping
Credential Access → OS Credential Dumping → LSASS Memory  

MITRE ATT&CK: **T1003.001**

---

## References
- MITRE ATT&CK T1003.001
- Sysinternals ProcDump documentation
- LOLBAS ProcDump entry

---

## Validation
The rule was validated with the following checks:

```
capafmt
```

```
lint --thorough -t "dump LSASS memory via ProcDump"
```

Both checks passed successfully.