### PR TITLE
rules: add nursery rule for shellcode execution via ReadDirectoryChanges

### DIFF
--- a/nursery/execute-shellcode-via-readdirectorychanges.yml
+++ b/nursery/execute-shellcode-via-readdirectorychanges.yml
@@ -1,0 +1,31 @@
+rule:
+  meta:
+    name: execute shellcode via ReadDirectoryChanges
+    namespace: load-code/shellcode
+    authors:
+      - akshatpal@users.noreply.github.com
+    description: detect execution of arbitrary shellcode via ReadDirectoryChanges completion routines
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Defense Evasion::Reflective Code Loading [T1620]
+    mbc:
+      - Defense Evasion::Hijack Execution Flow::Abuse Windows Function Calls [F0015.006]
+    references:
+      - https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw
+      - https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/nc-minwinbase-lpoverlapped_completion_routine
+  features:
+    - and:
+      - match: allocate or change RWX memory
+      - or:
+        - api: ReadDirectoryChangesW
+        - api: ReadDirectoryChangesExW
+      - or:
+        - api: SleepEx
+        - api: WaitForSingleObjectEx
+        - api: WaitForMultipleObjectsEx
+      - optional:
+        - or:
+          - api: CreateFileA
+          - api: CreateFileW

--- a/nursery/execute-shellcode-via-readdirectorychanges.yml
+++ b/nursery/execute-shellcode-via-readdirectorychanges.yml
@@ -19,13 +19,11 @@ rule:
     - and:
       - match: allocate or change RWX memory
       - or:
-        - api: ReadDirectoryChangesW
-        - api: ReadDirectoryChangesExW
+        - api: ReadDirectoryChanges
+        - api: ReadDirectoryChangesEx
       - or:
         - api: SleepEx
         - api: WaitForSingleObjectEx
         - api: WaitForMultipleObjectsEx
       - optional:
-        - or:
-          - api: CreateFileA
-          - api: CreateFileW
+        - api: CreateFile


### PR DESCRIPTION
## Summary

This PR adds a new nursery rule detecting potential shellcode execution triggered through the Windows `ReadDirectoryChanges` API callback flow.

The idea comes from the `rule-idea` issues and currently has no related PRs (GitHub search for `"ReadDirectoryChanges" shellcode execution` returned none).

## Detection logic

The rule looks for patterns where malware may use directory change notifications as a trigger for executing shellcode.

Typical flow includes:

- `ReadDirectoryChangesW` or `ReadDirectoryChangesExW`
- RWX memory allocation or permission change
- alertable wait APIs such as:
  - `SleepEx`
  - `WaitForSingleObjectEx`
  - `WaitForMultipleObjectsEx`

These APIs together can indicate a callback-driven execution path where shellcode is triggered by filesystem events.

## Rule location
rules/nursery/execute-shellcode-via-readdirectorychanges.yml

## Validation

Formatting and lint checks pass:
HOME=/tmp .venv/bin/python scripts/capafmt.py -c rules/nursery/execute-shellcode-via-readdirectorychanges.yml
HOME=/tmp .venv/bin/python scripts/lint.py -t “execute shellcode via ReadDirectoryChanges” rules

Both commands completed successfully.

## Notes

This rule is added to **nursery** because it may benefit from additional testing and refinement before promotion to the main ruleset.