### PR TITLE
rules: add nursery rule for systemd CLI interaction on Linux

### DIFF
--- a/nursery/interact-with-systemd-via-command-line-on-linux.yml
+++ b/nursery/interact-with-systemd-via-command-line-on-linux.yml
@@ -20,7 +20,6 @@ rule:
         - os: linux
       - or:
         - api: system
-        - api: _system
         - match: create process on Linux
       - or:
         - string: /\bsystemctl\b/i

--- a/nursery/interact-with-systemd-via-command-line-on-linux.yml
+++ b/nursery/interact-with-systemd-via-command-line-on-linux.yml
@@ -1,0 +1,28 @@
+rule:
+  meta:
+    name: interact with systemd via command line on Linux
+    namespace: host-interaction/service
+    authors:
+      - akshatpal@users.noreply.github.com
+    description: detect command-line interaction with systemd services or logs on Linux
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Discovery::System Service Discovery [T1007]
+    references:
+      - https://man7.org/linux/man-pages/man1/systemctl.1.html
+      - https://man7.org/linux/man-pages/man1/journalctl.1.html
+      - https://man7.org/linux/man-pages/man1/systemd-run.1.html
+  features:
+    - and:
+      - or:
+        - os: linux
+        - os: android
+      - or:
+        - match: execute command
+        - match: create process on Linux
+      - or:
+        - string: /\bsystemctl\b/i
+        - string: /\bjournalctl\b/i
+        - string: /\bsystemd-run\b/i

--- a/nursery/interact-with-systemd-via-command-line-on-linux.yml
+++ b/nursery/interact-with-systemd-via-command-line-on-linux.yml
@@ -3,10 +3,10 @@ rule:
     name: interact with systemd via command line on Linux
     namespace: host-interaction/service
     authors:
-      - akshatpal@users.noreply.github.com
+      - akshatpal
     description: detect command-line interaction with systemd services or logs on Linux
     scopes:
-      static: function
+      static: basic block
       dynamic: call
     att&ck:
       - Discovery::System Service Discovery [T1007]
@@ -18,9 +18,9 @@ rule:
     - and:
       - or:
         - os: linux
-        - os: android
       - or:
-        - match: execute command
+        - api: system
+        - api: _system
         - match: create process on Linux
       - or:
         - string: /\bsystemctl\b/i


### PR DESCRIPTION
Add a new nursery rule detecting Linux command-line interaction with
systemd components (systemctl, journalctl, systemd-run).

The rule matches when a function:
- targets Linux/Android
- executes a command or creates a Linux process
- references systemctl, journalctl, or systemd-run

Validated with capafmt and lint.