### PR TITLE
feat(rules): detect ReadDirectoryChanges shellcode via callback and APC (#1095)

### DIFF
--- a/load-code/shellcode/execute-shellcode-via-readdirectorychanges.yml
+++ b/load-code/shellcode/execute-shellcode-via-readdirectorychanges.yml
@@ -1,0 +1,31 @@
+rule:
+  meta:
+    name: execute shellcode via ReadDirectoryChanges APC
+    namespace: load-code/shellcode
+    authors:
+      - sherkhanz
+    description: Detects abuse of the ReadDirectoryChanges API completion routine combined with an alertable wait state to execute shellcode.
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Defense Evasion::Process Injection::Asynchronous Procedure Call [T1055.004]
+    mbc:
+      - Defense Evasion::Hijack Execution Flow::Abuse Windows Function Calls [F0015.006]
+    references:
+      - https://github.com/mandiant/capa-rules/issues/1095
+      - https://osandamalith.com/2025/09/25/executing-shellcode-with-readdirectorychangess-hidden-callback/
+      - https://github.com/OsandaMalith/CallbackShellcode/blob/main/ReadDirectoryChanges.c
+  features:
+    - and:
+      - or:
+        - api: ReadDirectoryChangesW
+        - api: ReadDirectoryChangesA
+        - api: ReadDirectoryChangesExW
+        - api: ReadDirectoryChangesExA
+      - or:
+        - api: SleepEx
+        - api: WaitForSingleObjectEx
+        - api: WaitForMultipleObjectsEx
+        - api: MsgWaitForMultipleObjectsEx
+        - api: SignalObjectAndWait

--- a/load-code/shellcode/execute-shellcode-via-windows-callback-function.yml
+++ b/load-code/shellcode/execute-shellcode-via-windows-callback-function.yml
@@ -22,6 +22,7 @@ rule:
       - https://osandamalith.com/2021/04/01/executing-shellcode-via-callbacks/
       - https://github.com/tlsbollei/Malware-Training/blob/main/Code%20Injection/LdrCallEnclave.cpp
       - https://osandamalith.com/2025/10/18/rtlregisterwait-shellcode-execution-poc/
+      - https://osandamalith.com/2025/09/25/executing-shellcode-with-readdirectorychangess-hidden-callback/
     examples:
       - 10cd7afd580ee9c222b0a87ff241d306:0x10008BE0
       - 268d61837aa248c1d49a973612a129ce:0x1000CEC0
@@ -82,6 +83,10 @@ rule:
         - api: ImmEnumInputContext
         - api: LdrCallEnclave
         - api: LineDDA
+        - api: ReadDirectoryChangesA
+        - api: ReadDirectoryChangesW
+        - api: ReadDirectoryChangesExA
+        - api: ReadDirectoryChangesExW
         - and:
           - api: RtlRegisterWait
           - api: SetEvent


### PR DESCRIPTION
This PR resolves #1095. 
- Updated callback rule to include ReadDirectoryChanges.
- Added a new standalone rule for APC-based execution (targeting the provided PoC).

**References**
- https://osandamalith.com/2025/09/25/executing-shellcode-with-readdirectorychangess-hidden-callback/
- https://github.com/OsandaMalith/CallbackShellcode/blob/main/ReadDirectoryChanges.c

<img width="1518" height="602" alt="image" src="https://github.com/user-attachments/assets/215e6688-1c74-4d75-83c7-41f44f242806" />

_Rule validation against the standalone YAML file_

<img width="1558" height="905" alt="image" src="https://github.com/user-attachments/assets/185db233-14af-4541-bd55-f03d758f7e90" />

_Validation within the full ruleset context_

Fixes #1095