### PR TITLE
add rule for detecting opening of service by ransomwares

### DIFF
--- a/host-interaction/service/open/open-service-by-ransomware.yml
+++ b/host-interaction/service/open/open-service-by-ransomware.yml
@@ -1,0 +1,55 @@
+rule:
+  meta:
+    name: open service by ransomware
+    namespace: host-interaction/service/open
+    authors:
+      - github - @cipherBT
+    description: Detects when a ransomware tries to open services known to be associared to them
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Impact::Inhibit system recovery [T1490]
+      - Defense Evasion::Disable/moify tools [F004.004]
+    examples:
+      - ""
+  features:
+    - and:
+      # Call a windows api
+      - or:
+        - api: advapi32.OpenService
+        - api: advapi32.ControlService
+        - api: advapi32.DeleteService
+      # Reference one of the typical ransomware targets from Netskope
+      -or:
+        - string: "vss"   
+        - string: "sql"        
+        - string: "backup"
+        - string: "svc$"
+        - string: "VSS"
+        # Specific Antivirus/Security/Backup targets
+        - string: "sophos"
+        - string: "veeam"
+        - string: "memtas"
+        - string: "mepocs"
+        - string: "GxVss"
+        - string: "GxBlr"
+        - string: "GxFWD"
+        - string: "GxCVD"
+        - string: "GxCIC"
+        - string: "DefWatch"
+        - string: "ccevtmgr"
+        - string: "ccSetMgr"
+        - string: "SavRoam"
+        - string: "RTVscan"
+        - string: "zhudongfangyu"
+        - string: "stisvc"
+        - string: "UI0Detect"
+        # QuickBooks / Accounting software targets
+        - string: "QBFCService"
+        - string: "QBIDPService"
+        - string: "Intuit.QuickBooks.FCS"
+        - string: "QBCFMonitorService"   
+        # Other specified IOCs
+        - string: "YooBackup"
+        - string: "YooIT"


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
Resolves issue #1048. Hi, my name is Fatiu and I'm taking a look at some good first issues for GSoC 2026. This PR adds a rule to detect when a binary attempts to open/control services consistently targeted by ransomware compiled from the Netskope IOC list mentioned in the issue.
Currently, the examples section is blank as I don't have a direct sample hash hitting it. I'd appreciate any feedback. Thank you