### PR TITLE
add rule to detect ransomware targeting services via OpenService calls

### DIFF
--- a/impact/inhibit-system-recovery/target-services-for-ransomware.yml
+++ b/impact/inhibit-system-recovery/target-services-for-ransomware.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: target services for ransomware
+    namespace: impact/inhibit-system-recovery
+    authors:
+      - AnasRm01
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Impact::Inhibit System Recovery [T1490]
+      - Impact::Service Stop [T1489]
+    references:
+      - https://github.com/netskopeoss/NetskopeThreatLabsIOCs/blob/main/Malware/BlackMatter/IOCs/README.md
+  features:
+    - or:
+      - and:
+        - api: OpenServiceA
+        - api: ControlService
+      - and:
+        - api: OpenServiceW
+        - api: ControlService


### PR DESCRIPTION
Closes #1048

This rule detects ransomware behavior of targeting and stopping 
critical Windows services using OpenService API calls.

Ransomware families like BlackMatter attempt to open and stop 
services such as backup and recovery services before encrypting 
files. This rule identifies that behavior by detecting OpenServiceA 
or OpenServiceW combined with ControlService API calls.

References:
- https://github.com/netskopeoss/NetskopeThreatLabsIOCs/blob/main/Malware/BlackMatter/IOCs/README.md