### PR TITLE
rule: reference ConfuserEx anti-profiling (fixes #602)

### DIFF
--- a/anti-analysis/anti-debugging/reference-confuserex-anti-profiling.yml
+++ b/anti-analysis/anti-debugging/reference-confuserex-anti-profiling.yml
@@ -3,8 +3,8 @@ rule:
     name: reference ConfuserEx anti-profiling
     namespace: anti-analysis/anti-debugging
     author: Nitezio
-    description: Detects strings associated with ConfuserEx's anti-profiling mechanisms, which patch the CLR and hijack named pipes to prevent managed profilers from attaching.
-    scope: file
+    description: Detects ConfuserEx's anti-profiling mechanisms, which patch the CLR and hijack named pipes to prevent managed profilers from attaching.
+    scope: function
     att&ck:
       - Defense Evasion::Impair Defenses::Disable or Modify Tools [T1562.001]
     references:
@@ -12,5 +12,13 @@ rule:
       - https://github.com/yck1509/ConfuserEx/blob/master/Confuser.Runtime/antinet/AntiManagedProfiler.cs
   features:
     - or:
-      - string: "ProfAPIMaxWaitForTriggerMs"
-      - string: "\\\\.\\pipe\\CPFATP_{0}_v{1}.{2}.{3}"
+      # Behavior 1: Modifying the CLR timeout via memory protection
+      - and:
+        - api: kernel32.VirtualProtect
+        - string: "ProfAPIMaxWaitForTriggerMs"
+      # Behavior 2: Hijacking the CLR profiler named pipe
+      - and:
+        - string: "\\\\.\\pipe\\CPFATP_{0}_v{1}.{2}.{3}"
+        - or:
+          - api: kernel32.CreateNamedPipe
+          - api: kernel32.CreateFile

--- a/anti-analysis/anti-debugging/reference-confuserex-anti-profiling.yml
+++ b/anti-analysis/anti-debugging/reference-confuserex-anti-profiling.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: reference ConfuserEx anti-profiling
+    namespace: anti-analysis/anti-debugging
+    author: Nitezio
+    description: Detects strings associated with ConfuserEx's anti-profiling mechanisms, which patch the CLR and hijack named pipes to prevent managed profilers from attaching.
+    scope: file
+    att&ck:
+      - Defense Evasion::Impair Defenses::Disable or Modify Tools [T1562.001]
+    references:
+      - https://github.com/mandiant/capa-rules/issues/602
+      - https://github.com/yck1509/ConfuserEx/blob/master/Confuser.Runtime/antinet/AntiManagedProfiler.cs
+  features:
+    - or:
+      - string: "ProfAPIMaxWaitForTriggerMs"
+      - string: "\\\\.\\pipe\\CPFATP_{0}_v{1}.{2}.{3}"


### PR DESCRIPTION
closes #602

This PR introduces a file-scope rule to detect the specific anti-profiling techniques used by the ConfuserEx .NET obfuscator. 

As requested in the issue, analyzing the `AntiManagedProfiler.cs` source code reveals that it prevents profiler attachment by hijacking the CLR's named pipe and manipulating the `ProfAPIMaxWaitForTriggerMs` timeout. This rule flags the presence of those specific, hard-coded strings.

*Note: I am submitting this as my preliminary code contribution for my GSoC 2026 application regarding the capa Automated Rule Generation Agent.*