### PR TITLE
Fix false positive in persist via Windows service rule

### DIFF
--- a/persistence/service/persist-via-windows-service.yml
+++ b/persistence/service/persist-via-windows-service.yml
@@ -39,4 +39,7 @@ rule:
           - string: /New-Service /i
       - and:
         - match: set registry value
-        - string: /System\\(ControlSet\d{3}|CurrentControlSet)\\Services/i
+        - string: /System\(ControlSet\d{3}|CurrentControlSet)\Services/i
+        - or:
+          - string: /ImagePath/i
+          - string: /StartType/i


### PR DESCRIPTION
Fixes #1100

Adds constraint to the registry-based persistence detection to avoid matching unrelated registry modifications like NetbiosOptions.

The rule now requires the registry value being set to be either ImagePath or StartType, which are the registry keys used for actual service binary path persistence, not arbitrary NetBT parameters.

This prevents false positives while maintaining detection of legitimate Windows service persistence mechanisms.


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
