### PR TITLE
Fix namespace typo error

### DIFF
--- a/nursery/get-current-process-command-line.yml
+++ b/nursery/get-current-process-command-line.yml
@@ -1,7 +1,7 @@
 rule:
   meta:
     name: get current process command line
-    namespace: host-interation/process
+    namespace: host-interaction/process
     authors:
       - william.ballenthin@mandiant.com
     scopes:

--- a/nursery/get-current-process-file-path.yml
+++ b/nursery/get-current-process-file-path.yml
@@ -1,7 +1,7 @@
 rule:
   meta:
     name: get current process file path
-    namespace: host-interation/process
+    namespace: host-interaction/process
     authors:
       - william.ballenthin@mandiant.com
     scopes:

--- a/nursery/get-current-process-filesystem-mounts-on-linux.yml
+++ b/nursery/get-current-process-filesystem-mounts-on-linux.yml
@@ -1,7 +1,7 @@
 rule:
   meta:
     name: get current process filesystem mounts on Linux
-    namespace: host-interation/process
+    namespace: host-interaction/process
     authors:
       - mehunhoff@google.com
     scopes:

--- a/nursery/get-current-process-memory-mapping-on-linux.yml
+++ b/nursery/get-current-process-memory-mapping-on-linux.yml
@@ -1,7 +1,7 @@
 rule:
   meta:
     name: get current process memory mapping on Linux
-    namespace: host-interation/process
+    namespace: host-interaction/process
     authors:
       - mehunhoff@google.com
     scopes:

--- a/nursery/get-system-property-on-android.yml
+++ b/nursery/get-system-property-on-android.yml
@@ -1,7 +1,7 @@
 rule:
   meta:
     name: get system property on Android
-    namespace: host-interation/process
+    namespace: host-interaction/process
     authors:
       - mehunhoff@google.com
     scopes:


### PR DESCRIPTION
This PR fixes a typo in the capa rules where the namespace was incorrectly specified as:
```
host-interation
```
It should be:
```
host-interaction
```
