### PR TITLE
rules: detect ps2exe binaries compiled with current MainApp/MainModule naming

### DIFF
--- a/compiler/ps2exe/compiled-with-ps2exe.yml
+++ b/compiler/ps2exe/compiled-with-ps2exe.yml
@@ -14,6 +14,7 @@ rule:
     examples:
       - 8775ed26068788279726e08ff9665aab
       - 805f79e57e4ce24b95a04541e4ea55dd2ce9ba314ab2c43491328204bc25d017
+      - 9df11356c5ac61d2aa7b5425e6322fc016b0ed5790dacb201396500b3eee03f7
   features:
     - and:
       - match: compiled to the .NET platform

--- a/compiler/ps2exe/compiled-with-ps2exe.yml
+++ b/compiler/ps2exe/compiled-with-ps2exe.yml
@@ -5,6 +5,7 @@ rule:
     authors:
       - "@_re_fox"
       - jakub.jozwiak@mandiant.com
+      - "@shreethaar"
     scopes:
       static: file
       dynamic: file

--- a/compiler/ps2exe/compiled-with-ps2exe.yml
+++ b/compiler/ps2exe/compiled-with-ps2exe.yml
@@ -25,3 +25,7 @@ rule:
         - and:
           - string: "If you spzzcify thzz -zzxtract option you nzzed to add a filzz for zzxtraction in this way"
           - string: "   -zzxtract:\"<filzznamzz>\""
+        - and:
+          - string: "ModuleNameSpace"
+          - string: "MainAppInterface"
+          - string: "ConsoleColorProxy"


### PR DESCRIPTION
This adds detection coverage for PS2EXE's current code-generation
template. PS2EXE renamed its internal PSHost implementation classes
at some point after the samples this rule was originally written
against — older builds embed `PS2EXEApp`/`PS2EXE_Host`, while the
current MScholtes/PS2EXE master (confirmed against v0.5.0.33,
2025-08-19) generates `ModuleNameSpace.MainApp` / `MainModule*` /
`ConsoleColorProxy` instead. Binaries compiled with a current PS2EXE
install were producing false negatives against this rule.

Verified with a SantaStealer sample in the wild (sha256:
9df11356c5ac61d2aa7b5425e6322fc016b0ed5790dacb201396500b3eee03f7)
that was previously going undetected by this rule.

Sample uploaded to capa-testfiles: mandiant/capa-testfiles#316

Ran:
- `python scripts/lint.py .` (clean)
- `python scripts/lint.py --thorough -t "compiled with ps2exe" -v --samples .. .`
  — note: surfaces an unrelated FAIL on the dependency rule
  `compiled to the .NET platform` since its own examples aren't in my
  local sample set; full corpus validation runs in CI against the
  complete capa-testfiles checkout.