### PR TITLE
Fix rule incompatibility with dynamic feature extractors

### DIFF
--- a/malware-family/plugx/match-known-plugx-module.yml
+++ b/malware-family/plugx/match-known-plugx-module.yml
@@ -8,7 +8,7 @@ rule:
     description: the sample references known PlugX watermarks (hexified YYYYMMDD + command opcode)
     scopes:
       static: function
-      dynamic: span of calls
+      dynamic: unsupported # requires mnemonic
     references:
       - https://circl.lu/assets/files/tr-12/tr-12-circl-plugx-analysis-v1.pdf
       - https://www.fireeye.com/blog/threat-research/2014/07/pacific-ring-of-fire-plugx-kaba.html


### PR DESCRIPTION
When filtering for dynamic unsupported I have found that the rule `match known PlugX module` matches only using static features, afaik mnemonics are not supported by dynamic features extractors like cape or drakvuf 