### PR TITLE
Improve .NET AoT detection logic

### DIFF
--- a/runtime/dotnet/compiled-with-dotnet-aot.yml
+++ b/runtime/dotnet/compiled-with-dotnet-aot.yml
@@ -10,14 +10,33 @@ rule:
       dynamic: file
     references:
       - https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/
+      - https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/Bootstrap/main.cpp
+      - https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+      - https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
     examples:
       - 684cc28e6a7fbd12f23dbc563f06306555ebb870bd727ad60839d4ff26e7f3b2
   features:
-    - and:
-      - substring: ".NETCoreApp,Version="
+    - or:
+      - export: DotNetRuntimeDebugHeader
+        description: runtime debug header exported by .NET 8+ AoT binaries unless DebuggerSupport is disabled
       - 2 or more:
-        - substring: "AotAnalysis4IL"
-        - substring: "https://aka.ms/nativeaot-compatibilit"
-        - substring: "removed by the AOT compiler"
-        - substring: "\\native\\"
-          description: During compilation, the output by default contains the path "native," which is then in turn included in the PDB path.
+        - section: .managed
+          description: managed code section emitted by .NET 7/8 era ILCompiler on Windows
+        - section: hydrated
+          description: data rehydration section, default on Linux and in .NET 8 era or size-optimized Windows builds
+        - substring: ".managedcode$A"
+          description: section marker bracketing AoT-compiled managed code on Windows
+        - substring: ".modules$A"
+          description: section marker bracketing AoT module headers on Windows
+        - substring: ".unbox$A"
+          description: section marker bracketing AoT unboxing stubs on Windows
+        - substring: "__managedcode"
+          description: section and bracketing symbols holding AoT-compiled managed code on Linux
+        - substring: "System.Private.TypeLoader"
+          description: managed runtime assembly only present in AoT binaries
+        - substring: "System.Private.Reflection.Execution"
+          description: managed runtime assembly only present in AoT binaries
+        - string: "Fatal error. Invalid Program: attempted to call a UnmanagedCallersOnly method from managed code."
+          description: fail-fast message from the statically linked AoT runtime
+        - string: "Process is terminating due to StackOverflowException."
+          description: fail-fast message from the statically linked AoT runtime

--- a/runtime/dotnet/compiled-with-dotnet-aot.yml
+++ b/runtime/dotnet/compiled-with-dotnet-aot.yml
@@ -32,11 +32,14 @@ rule:
           description: section marker bracketing AoT unboxing stubs on Windows
         - substring: "__managedcode"
           description: section and bracketing symbols holding AoT-compiled managed code on Linux
-        - substring: "System.Private.TypeLoader"
-          description: managed runtime assembly only present in AoT binaries
-        - substring: "System.Private.Reflection.Execution"
-          description: managed runtime assembly only present in AoT binaries
         - string: "Fatal error. Invalid Program: attempted to call a UnmanagedCallersOnly method from managed code."
           description: fail-fast message from the statically linked AoT runtime
         - string: "Process is terminating due to StackOverflowException."
           description: fail-fast message from the statically linked AoT runtime
+      - 2 or more:
+        - substring: "System.Private.TypeLoader"
+          description: managed runtime assembly only present in AoT binaries
+        - substring: "System.Private.Reflection.Execution"
+          description: managed runtime assembly only present in AoT binaries
+        - substring: "System.Private.StackTraceMetadata"
+          description: managed runtime assembly only present in AoT binaries


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


## Summary

In the previous logic for detecting .NET Ahead-of-Time compiled applications, the rule naively assumed the AoT compiler would include the .NET Core version number and AoT-compilation-related warnings. This is no longer the case for .NET 10, and the rule would fail to detect .NET 10 AoT compiled binaries. The rule would also sometimes hit false positives against certain single-file .NET builds that aren't necessarily AoT-generated.

This PR revisits the .NET runtime source code to check for ground-truth on how AoT applications are generated. There are a few things I found during the research,

- The .NET runtime compiler now exports `DotNetRuntimeDebugHeader` - this should work as a reliable indicator for .NET 8 AoT binaries when `DebuggerSupport` is enabled (default).
- Certain types and exception messages are included to hint that AoT was involved in the compilation process.
- Additional section names (especially the hydratable data in .NET 8) are present in AoT-specific builds.

The PR replaces the existing logic with the findings above.