### PR TITLE
Support for systemd-related behaviors

### DIFF
--- a/nursery/clear-system-logs-via-journalctl.yml
+++ b/nursery/clear-system-logs-via-journalctl.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: clear system logs via journalctl
+    namespace: anti-analysis/anti-forensic/clear-logs
+    authors:
+      - still@teamt5.org
+    scopes:
+      static: file
+      dynamic: file
+    att&ck:
+      - Defense Evasion::Indicator Removal::Clear Linux or Mac System Logs [T1070.002]
+    examples:
+      - 6a5bda892608df18c543036b71f46dd2ae533c85256c40dffeb23ea78c70f021
+  features:
+    - and:
+      - os: linux
+      - string: /\bjournalctl\s+(--?\S+\s+)*--(rotate|vacuum-time|vacuum-size|vacuum-files)/

--- a/nursery/clear-system-logs-via-journalctl.yml
+++ b/nursery/clear-system-logs-via-journalctl.yml
@@ -10,7 +10,7 @@ rule:
     att&ck:
       - Defense Evasion::Indicator Removal::Clear Linux or Mac System Logs [T1070.002]
     examples:
-      - 6a5bda892608df18c543036b71f46dd2ae533c85256c40dffeb23ea78c70f021
+      - 9a065f123d185623b6cb6762bd5a21cf1b836fbaeae0ef85b58aa76a97d5077b
   features:
     - and:
       - os: linux

--- a/nursery/interact-with-systemd-journal-via-journalctl.yml
+++ b/nursery/interact-with-systemd-journal-via-journalctl.yml
@@ -10,7 +10,7 @@ rule:
     att&ck:
       - Discovery::System Information Discovery [T1082]
     examples:
-      - 6a5bda892608df18c543036b71f46dd2ae533c85256c40dffeb23ea78c70f021
+      - 9a065f123d185623b6cb6762bd5a21cf1b836fbaeae0ef85b58aa76a97d5077b
   features:
     - and:
       - os: linux

--- a/nursery/interact-with-systemd-journal-via-journalctl.yml
+++ b/nursery/interact-with-systemd-journal-via-journalctl.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: interact with systemd journal via journalctl
+    namespace: host-interaction/log
+    authors:
+      - still@teamt5.org
+    scopes:
+      static: file
+      dynamic: file
+    att&ck:
+      - Discovery::System Information Discovery [T1082]
+    examples:
+      - 6a5bda892608df18c543036b71f46dd2ae533c85256c40dffeb23ea78c70f021
+  features:
+    - and:
+      - os: linux
+      - string: /\bjournalctl\s+-/

--- a/nursery/manage-system-services-via-systemctl.yml
+++ b/nursery/manage-system-services-via-systemctl.yml
@@ -11,7 +11,7 @@ rule:
       - Impact::Service Stop [T1489]
       - Persistence::Create or Modify System Process::Systemd Service [T1543.002]
     examples:
-      - 6a5bda892608df18c543036b71f46dd2ae533c85256c40dffeb23ea78c70f021
+      - 9a065f123d185623b6cb6762bd5a21cf1b836fbaeae0ef85b58aa76a97d5077b
   features:
     - and:
       - os: linux

--- a/nursery/manage-system-services-via-systemctl.yml
+++ b/nursery/manage-system-services-via-systemctl.yml
@@ -1,0 +1,18 @@
+rule:
+  meta:
+    name: manage system services via systemctl
+    namespace: host-interaction/service
+    authors:
+      - still@teamt5.org
+    scopes:
+      static: file
+      dynamic: file
+    att&ck:
+      - Impact::Service Stop [T1489]
+      - Persistence::Create or Modify System Process::Systemd Service [T1543.002]
+    examples:
+      - 6a5bda892608df18c543036b71f46dd2ae533c85256c40dffeb23ea78c70f021
+  features:
+    - and:
+      - os: linux
+      - string: /\bsystemctl\s+(--?\S+\s+)*(daemon-reload|daemon-reexec|start|stop|restart|reload|enable|disable|mask|unmask|kill|reset-failed)\b/


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->

## Summary

This PR aims to close #1041 by adding three new rules that address the behaviors of the sample mentioned in the issue. 
- nursery/clear-system-logs-via-journalctl.yml
- nursery/interact-with-systemd-journal-via-journalctl.yml
- nursery/manage-system-services-via-systemctl.yml

The rules are currently in nursery due to the following concerns, and additional discussion surrounding them are welcome,
- Linux rules aren't very prevalent in capa in general; some additional testing with more ITW samples might be preferred.
- The current implementations use regex - not sure if there are any rules or performance concerns regarding regex usage.
- The scopes are currently set to `file` instead of `function` due to the targeted sample being Go-based; `function`-based scoping seems to break the detection.