### PR TITLE
get-process-heap-flags: use GetProcessHeap

### DIFF
--- a/host-interaction/process/get-process-heap-flags.yml
+++ b/host-interaction/process/get-process-heap-flags.yml
@@ -15,7 +15,9 @@ rule:
       - al-khaser_x86.exe_:0x425470
   features:
     - and:
-      - match: PEB access
+      - or:
+        - match: PEB access
+        - api: GetProcessHeap
       - or:
         - and:
           - arch: i386


### PR DESCRIPTION
does not match our test sample because the `GetProcessHeap` call is split across basic blocks from the access to the field member. fixing that means increasing the scope from bb to function.

<img width="332" height="316" alt="image" src="https://github.com/user-attachments/assets/51e93099-42d6-4e2d-9c21-f8c6af329e38" />


closes #1183


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
