### PR TITLE
get-number-of-processors: add GetSystemInfo method

### DIFF
--- a/host-interaction/hardware/cpu/get-number-of-processors.yml
+++ b/host-interaction/hardware/cpu/get-number-of-processors.yml
@@ -25,4 +25,15 @@ rule:
           - and:
             - arch: amd64
             - number: 0xB8 = PEB->NumberOfProcessors
+      - and:
+        - or:
+          - api: GetSystemInfo
+          - api: GetNativeSystemInfo
+        - or:
+          - and:
+            - arch: i386
+            - operand[1].offset: 0x14 = SYSTEM_INFO.dwNumberOfProcessors
+          - and:
+            - arch: amd64
+            - operand[1].offset: 0x20 = SYSTEM_INFO.dwNumberOfProcessors
       - property/read: System.Environment::ProcessorCount


### PR DESCRIPTION
closes #1186


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
